### PR TITLE
chore: run test on release tags and add badge to releases in GH

### DIFF
--- a/.github/workflows/decorate-gh-release.yaml
+++ b/.github/workflows/decorate-gh-release.yaml
@@ -1,0 +1,28 @@
+name: Decorate Github release
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+jobs:
+  decorate-release:
+    name: Decorate Github release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add workflow status badge to a release
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const tag = context.ref.split("/")[2]
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+            const release = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+
+            const WORKFLOW_URL = `https://github.com/${owner}/${repo}/actions/workflows/test.yaml`
+            const BADGE = `[![Released chart test status](${WORKFLOW_URL}/badge.svg?tag=${tag})](${WORKFLOW_URL})`
+
+            await github.rest.repos.updateRelease({ owner, repo, release_id: release.data.id, body: BADGE + "\n\n" + release.data.body });

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,9 @@ on:
   pull_request_target: # zizmor: ignore[dangerous-triggers]
     branches:
       - main
+  push:
+    tags:
+      - "**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}


### PR DESCRIPTION
Resolves: https://github.com/neuralmagic/llm-d-deployer/issues/4

A little trick to update the release we create by chart releaser ☺️ 