### PR TITLE
feat: migrate to community redis image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,13 +68,6 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: login to registry.redhat.io
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
-        with:
-          registry: registry.redhat.io
-          username: ${{ secrets.REG_RH_USER }}
-          password: ${{ secrets.REG_RH_PASS }}
-
       - name: Create KIND Cluster
         if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0

--- a/charts/llm-d/Chart.yaml
+++ b/charts/llm-d/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: llm-d
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "0.0.1"
 icon: data:null
 description: A Helm chart for llm-d

--- a/charts/llm-d/README.md
+++ b/charts/llm-d/README.md
@@ -1,7 +1,7 @@
 
 # llm-d Helm Chart for OpenShift
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for llm-d

--- a/charts/llm-d/values.yaml
+++ b/charts/llm-d/values.yaml
@@ -275,9 +275,9 @@ redis:
   enabled: true
   architecture: standalone
   image:
-    registry: registry.redhat.io
-    repository: rhel9/redis-7
-    tag: 9.5-1744185101
+    registry: quay.io
+    repository: sclorg/redis-7-c9s
+    tag: c9s
   master:
     kind: Deployment
     resources:

--- a/quickstart/README-minikube.md
+++ b/quickstart/README-minikube.md
@@ -71,14 +71,12 @@ Create with Docker:
 
 ```bash
 docker --config ~/.config/containers/ login quay.io
-docker --config ~/.config/containers/ login registry.redhat.io
 ```
 
 Create with Podman:
 
 ```bash
 podman login quay.io --authfile ~/.config/containers/auth.json
-podman login registry.redhat.io --authfile ~/.config/containers/auth.json
 ```
 
 > ⚠️ You may need to visit Hugging Face [meta-llama/Llama-3.2-3B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct) and

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -104,14 +104,12 @@ Create with Docker:
 
 ```bash
 docker --config ~/.config/containers/ login quay.io
-docker --config ~/.config/containers/ login registry.redhat.io
 ```
 
 Create with Podman:
 
 ```bash
 podman login quay.io --authfile ~/.config/containers/auth.json
-podman login registry.redhat.io --authfile ~/.config/containers/auth.json
 ```
 
 ### Target Platforms

--- a/quickstart/llmd-installer-minikube.sh
+++ b/quickstart/llmd-installer-minikube.sh
@@ -134,11 +134,9 @@ locate_auth_file() {
     echo
     echo "# Docker"
     echo "docker --config ~/.config/containers/ login quay.io"
-    echo "docker --config ~/.config/containers/ login registry.redhat.io"
     echo
     echo "# Podman"
     echo "podman login quay.io  --authfile ~/.config/containers/auth.json"
-    echo "podman login registry.redhat.io  --authfile ~/.config/containers/auth.json"
     exit 1
   fi
   log_success "✅ Auth file: ${AUTH_FILE}"

--- a/quickstart/llmd-installer.sh
+++ b/quickstart/llmd-installer.sh
@@ -126,11 +126,9 @@ locate_auth_file() {
     echo
     echo "# Docker"
     echo "docker --config ~/.config/containers/ login quay.io"
-    echo "docker --config ~/.config/containers/ login registry.redhat.io"
     echo
     echo "# Podman"
     echo "podman login quay.io  --authfile ~/.config/containers/auth.json"
-    echo "podman login registry.redhat.io  --authfile ~/.config/containers/auth.json"
     exit 1
   fi
   log_success "✅ Auth file: ${AUTH_FILE}"


### PR DESCRIPTION
Resolves #29 

The image should be equivalent, just uses CentOS 9 Stream instead of RHEL 9.

This also removes the requirement for `registry.redhat.io` creds.