### PR TITLE
feat: reconcile on preset change

### DIFF
--- a/charts/llm-d/Chart.yaml
+++ b/charts/llm-d/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: llm-d
 type: application
-version: 0.5.4
+version: 0.5.5
 appVersion: "0.0.1"
 icon: data:null
 description: A Helm chart for llm-d

--- a/charts/llm-d/README.md
+++ b/charts/llm-d/README.md
@@ -1,7 +1,7 @@
 
 # llm-d Helm Chart for OpenShift
 
-![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square)
+![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for llm-d

--- a/charts/llm-d/templates/modelservice/deployment.yaml
+++ b/charts/llm-d/templates/modelservice/deployment.yaml
@@ -36,6 +36,9 @@ spec:
         {{- if .Values.modelservice.podAnnotations }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.modelservice.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
+        {{- range (list "gpu-with-nixl") }}
+        checksum/preset-{{ include "modelservice.fullname" $ }}-basic-gpu-with-nixl-preset: {{ pick ( include (print $.Template.BasePath "/modelservice/presets/basic-" . "-preset.yaml") $ | fromYaml ) "data" | toYaml | sha256sum }}
+        {{- end }}
     spec:
       containers:
       - args:


### PR DESCRIPTION
We should trigger a deployment rollout whenever preset config has changed. The idea is that we can extend `list("gpu-with-nixl")` with additional presets when we enable them.