### PR TITLE
docs: Neater preset table for NOTES.txt

### DIFF
--- a/charts/llm-d/Chart.yaml
+++ b/charts/llm-d/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: llm-d
 type: application
-version: 0.7.2
+version: 0.7.3
 appVersion: "0.0.1"
 icon: data:null
 description: A Helm chart for llm-d

--- a/charts/llm-d/README.md
+++ b/charts/llm-d/README.md
@@ -1,7 +1,7 @@
 
 # llm-d Helm Chart for OpenShift
 
-![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square)
+![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for llm-d

--- a/charts/llm-d/templates/NOTES.txt
+++ b/charts/llm-d/templates/NOTES.txt
@@ -9,11 +9,13 @@ To learn more about the release, try:
 
 Following presets are available to your users:
 
-| Name                                                               | Description                                                |
-| ------------------------------------------------------------------ | ---------------------------------------------------------- |
-| {{ include "modelservice.fullname" . }}-basic-gpu-preset           | Basic GPU inference                                        |
-| {{ include "modelservice.fullname" . }}-basic-gpu-with-nixl-preset | GPU inference with NIXL enabled and Redis cache offloading |
-| {{ include "modelservice.fullname" . }}-basic-sim-preset           | Basic simulation                                           |
+{{ $nameWidth := 50 }}
+{{ $descriptionWidth := 60 }}
+{{ include "tableRowPrinter" ( dict "nameWidth" $nameWidth "descriptionWidth" $descriptionWidth "name" "Name" "description" "Description" ) }}
+{{ include "tableRowPrinter" ( dict "nameWidth" $nameWidth "descriptionWidth" $descriptionWidth "spacer" "-" ) }}
+{{ include "tableRowPrinter" ( dict "nameWidth" $nameWidth "descriptionWidth" $descriptionWidth "name" (print (include "modelservice.fullname" .) "-basic-gpu-preset") "description" "Basic GPU inference" ) }}
+{{ include "tableRowPrinter" ( dict "nameWidth" $nameWidth "descriptionWidth" $descriptionWidth "name" (print (include "modelservice.fullname" .) "-basic-gpu-with-nixl-preset") "description" "GPU inference with NIXL enabled and Redis cache offloading" ) }}
+{{ include "tableRowPrinter" ( dict "nameWidth" $nameWidth "descriptionWidth" $descriptionWidth "name" (print (include "modelservice.fullname" .) "-basic-sim-preset") "description" "Basic simulation" ) }}
 
 
 {{ if not .Values.sampleApplication.enabled -}}

--- a/charts/llm-d/templates/_helpers.tpl
+++ b/charts/llm-d/templates/_helpers.tpl
@@ -10,3 +10,18 @@ FDQN for Redis master service in <svc_name>.<namespace>.svc.cluster.local:<port>
 {{- define "metrics.label" -}}
 llmd.ai/gather-metrics: "true"
 {{- end }}
+
+
+{{- define "padString" -}}
+{{- $length := len (default "" .text) -}}
+{{- if lt .width $length  }}
+{{- .text -}}
+{{- else -}}
+{{- $spacer := default " " .spacer  -}}
+{{- .text }}{{- range (until (sub $length .width | int )) -}}{{- print $spacer -}}{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tableRowPrinter" -}}
+| {{ include "padString"  ( dict "text" .name "width" .nameWidth "spacer" .spacer ) }} | {{ include "padString"  ( dict "text" .description "width" .descriptionWidth "spacer" .spacer ) }} |
+{{- end -}}


### PR DESCRIPTION
This PR turns:

```
| Name                                                               | Description                                                |
| ------------------------------------------------------------------ | ---------------------------------------------------------- |
| llm-d-modelservice-basic-gpu-preset | Basic GPU inference                                        |
| llm-d-modelservice-basic-gpu-with-nixl-preset | GPU inference with NIXL enabled and Redis cache offloading |
| llm-d-modelservice-basic-sim-preset           | Basic simulation                                           |
```

Into:

```
| Name                                               | Description                                                  |
| -------------------------------------------------- | ------------------------------------------------------------ |
| llm-d-modelservice-basic-gpu-preset                | Basic GPU inference                                          |
| llm-d-modelservice-basic-gpu-with-nixl-preset      | GPU inference with NIXL enabled and Redis cache offloading   |
| llm-d-modelservice-basic-sim-preset                | Basic simulation                                             |
```