### PR TITLE
Remove runasroot to fix decode breakage

### DIFF
--- a/charts/llm-d/Chart.yaml
+++ b/charts/llm-d/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: llm-d
 type: application
-version: 0.7.3
+version: 0.7.4
 appVersion: "0.0.1"
 icon: data:null
 description: A Helm chart for llm-d

--- a/charts/llm-d/README.md
+++ b/charts/llm-d/README.md
@@ -1,7 +1,7 @@
 
 # llm-d Helm Chart for OpenShift
 
-![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square)
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for llm-d

--- a/charts/llm-d/templates/modelservice/presets/basic-gpu-with-nixl-preset.yaml
+++ b/charts/llm-d/templates/modelservice/presets/basic-gpu-with-nixl-preset.yaml
@@ -33,7 +33,6 @@ data:
                 capabilities:
                   drop:
                     - MKNOD
-                runAsNonRoot: true
                 allowPrivilegeEscalation: false
               args:
                 - "--port=8000"
@@ -52,7 +51,6 @@ data:
                 capabilities:
                   drop:
                     - MKNOD
-                runAsNonRoot: true
                 allowPrivilegeEscalation: false
               command:
                 - vllm


### PR DESCRIPTION
- Fixes vanilla kube installs.
- Longer term, see if decode can be run as a regular user.