### PR TITLE
Add debug logging wrapper and model value file and dir

### DIFF
--- a/quickstart/README-minikube.md
+++ b/quickstart/README-minikube.md
@@ -150,6 +150,9 @@ For additional information regarding Minikube support with GPUs see [Using NVIDI
 ### Provision Minikube cluster with GPU support and install llm-d
 
 A hugging-face token is required either exported in your environment or passed via the `--hf-token` flag.
+You will need to run `--provision-minikube-gpu` at least once to provision the minikube container. After that,
+a common workflow might be to make some change to your code, run `--uninstall` to reset the minikube cluster to default
+and then run the installer again without the `--provision-minikube-gpu` flag.
 
 ```bash
 export HF_TOKEN="your-token"
@@ -290,6 +293,18 @@ Here is an example snippet of the default model values being replaced with
         name: llm-d-hf-token
         # -- Value of the token. Do not set this but use `envsubst` in conjunction with the helm chart
         key: HF_TOKEN
+```
+
+### Deploy with a Preconfigured Values File
+
+To make swapping in your own model even easier, we include a ready-to-use values files in[`quickstart/models/`](models/).
+
+Simply run the installer with the path to the included values file (or your own custom one) deploy the llm-d
+chart with all the correct overrides. These examples, also show you how you can pass custom arguments to vLLM
+prefill and decode pods.
+
+```bash
+./llmd-installer-minikube.sh --values-file models/gpt2-e2e-tiny-minikube.yaml
 ```
 
 ### Metrics Collection

--- a/quickstart/models/gpt2-e2e-tiny-minikube.yaml
+++ b/quickstart/models/gpt2-e2e-tiny-minikube.yaml
@@ -1,0 +1,42 @@
+# Validated to run with minikube on a single Nvidia L4 with 32G of RAM. EC2 type: g6.2xlarge
+sampleApplication:
+  enabled: true
+  model:
+    modelArtifactURI: pvc://model-pvc/models/openai-community/gpt2
+    modelName: "openai-community/gpt2"
+    servedModelNames: []
+    auth:
+      # -- HF token auth config via k8s secret.
+      hfToken:
+        # -- If the secret should be created or one already exists
+        create: true
+        # -- Name of the secret to create to store your huggingface token
+        name: llm-d-hf-token
+        # -- Value of the token. Do not set this but use `envsubst` in conjunction with the helm chart
+        key: HF_TOKEN
+  resources:
+    limits:
+      #nvidia.com/gpu: 1
+    requests:
+      # cpu: "16"
+      # memory: 16Gi
+      # Comment out the GPU request to so both p/d will spawn on a single GPU in a minikube node
+      # nvidia.com/gpu: 1
+  inferencePoolPort: 8000
+  prefill:
+    replicas: 1
+    # -- args to add to the prefill deployment
+    extraArgs:
+      - "--gpu-memory-utilization"
+      - "0.2"
+      - "--cpu-offload-gb"
+      - "8"
+  decode:
+    # -- number of desired decode replicas
+    replicas: 1
+    # -- args to add to the decode deployment
+    extraArgs:
+      - "--gpu-memory-utilization"
+      - "0.3"
+      - "--cpu-offload-gb"
+      - "8"


### PR DESCRIPTION
- Fills out the --debug mode to include logging
- Add a sample `quickstart/models` directory for pre-canned validated models. This is as much a placeholder for Llama4 and for tweaking to get how we want validated models to be available which is why I only updated the minikube readme for now.
- Fixes the relative path passing to `--values`

Closes #94 
Closes #78 