### PR TITLE
fix: remove `downloadModelJob.hfModelID` from the chart

### DIFF
--- a/charts/llm-d/Chart.yaml
+++ b/charts/llm-d/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: llm-d
 type: application
-version: 0.8.3
+version: 0.8.4
 appVersion: "0.0.1"
 icon: data:null
 description: A Helm chart for llm-d

--- a/charts/llm-d/README.md
+++ b/charts/llm-d/README.md
@@ -1,7 +1,7 @@
 
 # llm-d Helm Chart for OpenShift
 
-![Version: 0.8.3](https://img.shields.io/badge/Version-0.8.3-informational?style=flat-square)
+![Version: 0.8.4](https://img.shields.io/badge/Version-0.8.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for llm-d
@@ -251,7 +251,6 @@ Kubernetes: `>= 1.25.0-0`
 | nameOverride | String to partially override common.names.fullname | string | `""` |
 | redis | Bitnami/Redis chart configuration | object | Use sane defaults for minimal Redis deployment |
 | sampleApplication | Sample application deploying a p-d pair of specific model | object | See below |
-| sampleApplication.downloadModelJob.hfModelID | If `.Values.sampleApplication.model.modelArtifactURI` starts with `pvc://` what huggingface repo to load onto the pvc | string | `"meta-llama/Llama-3.2-3B-Instruct"` |
 | sampleApplication.enabled | Enable rendering of sample application resources | bool | `true` |
 | sampleApplication.inferencePoolPort | InferencePool port configuration | int | `8000` |
 | sampleApplication.model.auth.hfToken | HF token auth config via k8s secret. | object | `{"create":true,"key":"HF_TOKEN","name":"llm-d-hf-token"}` |

--- a/charts/llm-d/values.schema.json
+++ b/charts/llm-d/values.schema.json
@@ -1340,20 +1340,6 @@
       "default": "See below",
       "description": "Sample application deploying a p-d pair of specific model",
       "properties": {
-        "downloadModelJob": {
-          "additionalProperties": false,
-          "properties": {
-            "hfModelID": {
-              "default": "meta-llama/Llama-3.2-3B-Instruct",
-              "description": "If `.Values.sampleApplication.model.modelArtifactURI` starts with `pvc://` what huggingface repo to load onto the pvc",
-              "required": [],
-              "title": "hfModelID"
-            }
-          },
-          "required": [],
-          "title": "downloadModelJob",
-          "type": "object"
-        },
         "enabled": {
           "default": "true",
           "description": "Enable rendering of sample application resources",

--- a/charts/llm-d/values.yaml
+++ b/charts/llm-d/values.yaml
@@ -122,10 +122,6 @@ sampleApplication:
         # -- Value of the token. Do not set this but use `envsubst` in conjunction with the helm chart
         key: HF_TOKEN
 
-  downloadModelJob:
-      # -- If `.Values.sampleApplication.model.modelArtifactURI` starts with `pvc://` what huggingface repo to load onto the pvc
-    hfModelID: "meta-llama/Llama-3.2-3B-Instruct"
-
   # @schema
   # items:
   #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements

--- a/quickstart/README-minikube.md
+++ b/quickstart/README-minikube.md
@@ -290,10 +290,6 @@ Here is an example snippet of the default model values being replaced with
         name: llm-d-hf-token
         # -- Value of the token. Do not set this but use `envsubst` in conjunction with the helm chart
         key: HF_TOKEN
-
-  downloadModelJob:
-      # -- If `.Values.sampleApplication.model.modelArtifactURI` starts with `pvc://` what huggingface repo to load onto the pvc
-    hfModelID: "meta-llama/Llama-3.2-1B-Instruct"
 ```
 
 ### Metrics Collection

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -265,10 +265,6 @@ Here is an example snippet of the default model values being replaced with
         name: llm-d-hf-token
         # -- Value of the token. Do not set this but use `envsubst` in conjunction with the helm chart
         key: HF_TOKEN
-
-  downloadModelJob:
-      # -- If `.Values.sampleApplication.model.modelArtifactURI` starts with `pvc://` what huggingface repo to load onto the pvc
-    hfModelID: "meta-llama/Llama-3.2-1B-Instruct"
 ```
 
 ### Metrics Collection

--- a/quickstart/llmd-installer-minikube.sh
+++ b/quickstart/llmd-installer-minikube.sh
@@ -251,8 +251,13 @@ create_pvc_and_download_model_if_needed() {
         exit 1
     fi
     if [[ -z "${HF_MODEL_ID}" ]]; then
-        log_error "Error, \`modelArtifactURI\` indicates model from PVC, but no
-        Please set the \`.sampleApplication.downloadModelJob.hfModelID\` in the values file."
+        log_error "Error, \`modelArtifactURI\` indicates model from PVC, but no Hugging Face model is defined.
+        Please set the \`.sampleApplication.model.modelName\` in the values file."
+        exit 1
+    fi
+    if [[ "${HF_MODEL_ID}" == *"/"* ]]; then
+        log_error "Error, \`modelArtifactURI\` indicates model from PVC, but no Hugging Face model is defined.
+        Please set the \`.sampleApplication.model.modelName\` in a Hugging Face compliant format `<org>/<repo>`."
         exit 1
     fi
     if [[ -z "${HF_TOKEN_SECRET_NAME}" ]]; then
@@ -282,7 +287,7 @@ create_pvc_and_download_model_if_needed() {
     if [[ "${DOWNLOAD_MODEL}" == "true" ]]; then
       log_info "💾 Provisioning model storage…"
 
-      HF_MODEL_ID=$(yq '.sampleApplication.downloadModelJob.hfModelID' "${VALUES_PATH}" )
+      HF_MODEL_ID=$(yq '.sampleApplication.model.modelName' "${VALUES_PATH}" )
       HF_TOKEN_SECRET_NAME=$(yq '.sampleApplication.model.auth.hfToken.name' "${VALUES_PATH}" )
       HF_TOKEN_SECRET_KEY=$(yq '.sampleApplication.model.auth.hfToken.key' "${VALUES_PATH}" )
 

--- a/quickstart/llmd-installer.sh
+++ b/quickstart/llmd-installer.sh
@@ -168,8 +168,13 @@ create_pvc_and_download_model_if_needed() {
         exit 1
     fi
     if [[ -z "${HF_MODEL_ID}" ]]; then
-        log_error "Error, \`modelArtifactURI\` indicates model from PVC, but no
-        Please set the \`.sampleApplication.downloadModelJob.hfModelID\` in the values file."
+        log_error "Error, \`modelArtifactURI\` indicates model from PVC, but no Hugging Face model is defined.
+        Please set the \`.sampleApplication.model.modelName\` in the values file."
+        exit 1
+    fi
+    if [[ "${HF_MODEL_ID}" == *"/"* ]]; then
+        log_error "Error, \`modelArtifactURI\` indicates model from PVC, but no Hugging Face model is defined.
+        Please set the \`.sampleApplication.model.modelName\` in a Hugging Face compliant format `<org>/<repo>`."
         exit 1
     fi
     if [[ -z "${HF_TOKEN_SECRET_NAME}" ]]; then
@@ -199,7 +204,7 @@ create_pvc_and_download_model_if_needed() {
     if [[ "${DOWNLOAD_MODEL}" == "true" ]]; then
       log_info "💾 Provisioning model storage…"
 
-      HF_MODEL_ID=$(cat ${VALUES_PATH} | yq .sampleApplication.downloadModelJob.hfModelID)
+      HF_MODEL_ID=$(cat ${VALUES_PATH} | yq .sampleApplication.model.modelName)
       HF_TOKEN_SECRET_NAME=$(cat ${VALUES_PATH} | yq .sampleApplication.model.auth.hfToken.name)
       HF_TOKEN_SECRET_KEY=$(cat ${VALUES_PATH} | yq .sampleApplication.model.auth.hfToken.key)
 


### PR DESCRIPTION
When reviewing #112 I've noticed this slipped us when merging #21 

We can't have `values.yaml` properties that are not chart settings and modifying them has 0 effect on the chart, ever.

