### PR TITLE
feat: add helm json schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,17 @@ repos:
           - --template-files=./_templates.gotmpl
           # A base filename makes it relative to each chart directory found
           - --template-files=README.md.gotmpl
+  - repo: https://github.com/dadav/helm-schema
+    rev: "0.18.1"
+    hooks:
+      - id: helm-schema
+        args:
+          - --append-newline
+          - --chart-search-root=charts
+          - --add-schema-reference
+          - --helm-docs-compatibility-mode
+          - --skip-auto-generation=required
+          - --no-dependencies
   - repo: https://github.com/woodruffw/zizmor-pre-commit
     rev: v1.6.0
     hooks:

--- a/charts/llm-d/Chart.yaml
+++ b/charts/llm-d/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: llm-d
 type: application
-version: 0.8.2
+version: 0.8.3
 appVersion: "0.0.1"
 icon: data:null
 description: A Helm chart for llm-d

--- a/charts/llm-d/README.md
+++ b/charts/llm-d/README.md
@@ -1,7 +1,7 @@
 
 # llm-d Helm Chart for OpenShift
 
-![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square)
+![Version: 0.8.3](https://img.shields.io/badge/Version-0.8.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for llm-d
@@ -139,6 +139,7 @@ Kubernetes: `>= 1.25.0-0`
 | Key | Description | Type | Default |
 |-----|-------------|------|---------|
 | clusterDomain | Default Kubernetes cluster domain | string | `"cluster.local"` |
+| common | Parameters for bitnami.common dependency | object | `{}` |
 | commonAnnotations | Annotations to add to all deployed objects | object | `{}` |
 | commonLabels | Labels to add to all deployed objects | object | `{}` |
 | extraDeploy | Array of extra objects to deploy with the release | list | `[]` |
@@ -174,7 +175,12 @@ Kubernetes: `>= 1.25.0-0`
 | modelservice.epp | Endpoint picker configuration | object | See below |
 | modelservice.epp.defaultEnvVars | Default environment variables for endpoint picker, use `extraEnvVars` to override default behavior by defining the same variable again. Ref: https://github.com/neuralmagic/gateway-api-inference-extension/tree/dev?tab=readme-ov-file#temporary-fork-configuration | list | `[{"name":"ENABLE_KVCACHE_AWARE_SCORER","value":"false"},{"name":"KVCACHE_AWARE_SCORER_WEIGHT","value":"1.0"},{"name":"KVCACHE_INDEXER_REDIS_ADDR","value":"{{ if .Values.redis.enabled }}{{ include \"redis.master.service.fullurl\" . }}{{ end }}"},{"name":"ENABLE_PREFIX_AWARE_SCORER","value":"true"},{"name":"PREFIX_AWARE_SCORER_WEIGHT","value":"2.0"},{"name":"ENABLE_LOAD_AWARE_SCORER","value":"true"},{"name":"LOAD_AWARE_SCORER_WEIGHT","value":"1.0"},{"name":"ENABLE_SESSION_AWARE_SCORER","value":"false"},{"name":"SESSION_AWARE_SCORER_WEIGHT","value":"1.0"},{"name":"PD_ENABLED","value":"false"},{"name":"PD_PROMPT_LEN_THRESHOLD","value":"10"},{"name":"PREFILL_ENABLE_KVCACHE_AWARE_SCORER","value":"false"},{"name":"PREFILL_KVCACHE_AWARE_SCORER_WEIGHT","value":"1.0"},{"name":"PREFILL_ENABLE_LOAD_AWARE_SCORER","value":"false"},{"name":"PREFILL_LOAD_AWARE_SCORER_WEIGHT","value":"1.0"},{"name":"PREFILL_ENABLE_PREFIX_AWARE_SCORER","value":"false"},{"name":"PREFILL_PREFIX_AWARE_SCORER_WEIGHT","value":"1.0"},{"name":"DECODE_ENABLE_KVCACHE_AWARE_SCORER","value":"false"},{"name":"DECODE_KVCACHE_AWARE_SCORER_WEIGHT","value":"1.0"},{"name":"DECODE_ENABLE_LOAD_AWARE_SCORER","value":"false"},{"name":"DECODE_LOAD_AWARE_SCORER_WEIGHT","value":"1.0"},{"name":"DECODE_ENABLE_PREFIX_AWARE_SCORER","value":"false"},{"name":"DECODE_PREFIX_AWARE_SCORER_WEIGHT","value":"1.0"}]` |
 | modelservice.epp.extraEnvVars | Additional environment variables for endpoint picker | list | `[]` |
-| modelservice.epp.image | Endpoint picker image used in ModelService CR presets | object | `{"imagePullPolicy":"Always","registry":"quay.io","repository":"llm-d/llm-d-inference-scheduler","tag":"0.0.2"}` |
+| modelservice.epp.image | Endpoint picker image used in ModelService CR presets | object | See below |
+| modelservice.epp.image.imagePullPolicy | Specify a imagePullPolicy | string | `"Always"` |
+| modelservice.epp.image.pullSecrets | Optionally specify an array of imagePullSecrets (evaluated as templates) | list | `[]` |
+| modelservice.epp.image.registry | Endpoint picker image registry | string | `"quay.io"` |
+| modelservice.epp.image.repository | Endpoint picker image repository | string | `"llm-d/llm-d-inference-scheduler"` |
+| modelservice.epp.image.tag | Endpoint picker image tag | string | `"0.0.2"` |
 | modelservice.epp.metrics | Enable metrics gathering via podMonitor / ServiceMonitor | object | `{"enabled":true,"serviceMonitor":{"annotations":{},"interval":"10s","labels":{},"namespaceSelector":{"any":false,"matchNames":[]},"path":"/metrics","port":"metrics","selector":{"matchLabels":{}}}}` |
 | modelservice.epp.metrics.enabled | Enable metrics scraping from endpoint picker service | bool | `true` |
 | modelservice.epp.metrics.serviceMonitor | Prometheus ServiceMonitor configuration <br /> Ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md | object | See below |
@@ -186,7 +192,12 @@ Kubernetes: `>= 1.25.0-0`
 | modelservice.epp.metrics.serviceMonitor.port | ServiceMonitor endpoint port | string | `"metrics"` |
 | modelservice.epp.metrics.serviceMonitor.selector | ServiceMonitor selector matchLabels </br> matchLabels must match labels on modelservice Services | object | `{"matchLabels":{}}` |
 | modelservice.fullnameOverride | String to fully override modelservice.fullname | string | `""` |
-| modelservice.image | Modelservice controller image, please change only if appropriate adjustments to the CRD are being made | object | `{"imagePullPolicy":"Always","registry":"quay.io","repository":"llm-d/llm-d-model-service","tag":"0.0.9"}` |
+| modelservice.image | Modelservice controller image, please change only if appropriate adjustments to the CRD are being made | object | See below |
+| modelservice.image.imagePullPolicy | Specify a imagePullPolicy | string | `"Always"` |
+| modelservice.image.pullSecrets | Optionally specify an array of imagePullSecrets (evaluated as templates) | list | `[]` |
+| modelservice.image.registry | Model Service controller image registry | string | `"quay.io"` |
+| modelservice.image.repository | Model Service controller image repository | string | `"llm-d/llm-d-model-service"` |
+| modelservice.image.tag | Model Service controller image tag | string | `"0.0.9"` |
 | modelservice.metrics | Enable metrics gathering via podMonitor / ServiceMonitor | object | `{"enabled":true,"serviceMonitor":{"annotations":{},"interval":"15s","labels":{},"namespaceSelector":{"any":false,"matchNames":[]},"path":"/metrics","port":"vllm","selector":{"matchLabels":{}}}}` |
 | modelservice.metrics.enabled | Enable metrics scraping from prefill and decode services, see `model | bool | `true` |
 | modelservice.metrics.serviceMonitor | Prometheus ServiceMonitor configuration <br /> Ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md | object | See below |
@@ -206,7 +217,12 @@ Kubernetes: `>= 1.25.0-0`
 | modelservice.rbac.create | Enable the creation of RBAC resources | bool | `true` |
 | modelservice.replicas | Number of controller replicas | int | `1` |
 | modelservice.routingProxy | Routing proxy container options | object | See below |
-| modelservice.routingProxy.image | Routing proxy image used in ModelService CR presets | object | `{"imagePullPolicy":"Always","registry":"quay.io","repository":"llm-d/llm-d-routing-sidecar","tag":"0.0.6"}` |
+| modelservice.routingProxy.image | Routing proxy image used in ModelService CR presets | object | `{"imagePullPolicy":"IfNotPresent","pullSecrets":[],"registry":"quay.io","repository":"llm-d/llm-d-routing-sidecar","tag":"0.0.6"}` |
+| modelservice.routingProxy.image.imagePullPolicy | Specify a imagePullPolicy | string | `"IfNotPresent"` |
+| modelservice.routingProxy.image.pullSecrets | Optionally specify an array of imagePullSecrets (evaluated as templates) | list | `[]` |
+| modelservice.routingProxy.image.registry | Routing proxy image registry | string | `"quay.io"` |
+| modelservice.routingProxy.image.repository | Routing proxy image repository | string | `"llm-d/llm-d-routing-sidecar"` |
+| modelservice.routingProxy.image.tag | Routing proxy image tag | string | `"0.0.6"` |
 | modelservice.service.enabled | Toggle to deploy a Service resource for Model service controller | bool | `true` |
 | modelservice.service.port | Port number exposed from Model Service controller | int | `8443` |
 | modelservice.service.type | Service type | string | `"ClusterIP"` |
@@ -217,11 +233,21 @@ Kubernetes: `>= 1.25.0-0`
 | modelservice.serviceAccount.labels | Additional custom labels to the service ServiceAccount. | object | `{}` |
 | modelservice.serviceAccount.nameOverride | String to partially override modelservice.serviceAccountName, defaults to modelservice.fullname | string | `""` |
 | modelservice.vllm | vLLM container options | object | See below |
-| modelservice.vllm.image | vLLM image used in ModelService CR presets | object | `{"imagePullPolicy":"IfNotPresent","registry":"quay.io","repository":"llm-d/llm-d","tag":"0.0.7"}` |
+| modelservice.vllm.image | vLLM image used in ModelService CR presets | object | See below |
+| modelservice.vllm.image.imagePullPolicy | Specify a imagePullPolicy | string | `"IfNotPresent"` |
+| modelservice.vllm.image.pullSecrets | Optionally specify an array of imagePullSecrets (evaluated as templates) | list | `[]` |
+| modelservice.vllm.image.registry | llm-d image registry | string | `"quay.io"` |
+| modelservice.vllm.image.repository | llm-d image repository | string | `"llm-d/llm-d"` |
+| modelservice.vllm.image.tag | llm-d image tag | string | `"0.0.7"` |
 | modelservice.vllm.metrics | Enable metrics gathering via podMonitor / ServiceMonitor | object | `{"enabled":true}` |
 | modelservice.vllm.metrics.enabled | Enable metrics scraping from prefill & decode services | bool | `true` |
 | modelservice.vllmSim | vLL sim container options | object | See below |
-| modelservice.vllmSim.image | vLLM sim image used in ModelService CR presets | object | `{"imagePullPolicy":"IfNotPresent","registry":"quay.io","repository":"llm-d/vllm-sim","tag":"0.0.4"}` |
+| modelservice.vllmSim.image | vLLM sim image used in ModelService CR presets | object | See below |
+| modelservice.vllmSim.image.imagePullPolicy | Specify a imagePullPolicy | string | `"IfNotPresent"` |
+| modelservice.vllmSim.image.pullSecrets | Optionally specify an array of imagePullSecrets (evaluated as templates) | list | `[]` |
+| modelservice.vllmSim.image.registry | vllm-sim image registry | string | `"quay.io"` |
+| modelservice.vllmSim.image.repository | vllm-sim image repository | string | `"llm-d/vllm-sim"` |
+| modelservice.vllmSim.image.tag | vllm-sim image tag | string | `"0.0.4"` |
 | nameOverride | String to partially override common.names.fullname | string | `""` |
 | redis | Bitnami/Redis chart configuration | object | Use sane defaults for minimal Redis deployment |
 | sampleApplication | Sample application deploying a p-d pair of specific model | object | See below |
@@ -236,8 +262,10 @@ Kubernetes: `>= 1.25.0-0`
 | sampleApplication.model.modelName | Name of the model | string | `"meta-llama/Llama-3.2-3B-Instruct"` |
 | sampleApplication.model.servedModelNames | Aliases to the Model named vllm will serve with | list | `[]` |
 | sampleApplication.resources | Resource requests/limits <br /> Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container | object | `{"limits":{"nvidia.com/gpu":1},"requests":{"nvidia.com/gpu":1}}` |
-| test | Helm tests | object | `{"enabled":false,"image":{"registry":"quay.io","repository":"curl/curl","tag":"latest"}}` |
+| test | Helm tests | object | `{"enabled":false,"image":{"imagePullPolicy":"Always","pullSecrets":[],"registry":"quay.io","repository":"curl/curl","tag":"latest"}}` |
 | test.enabled | Enable rendering of helm test resources | bool | `false` |
+| test.image.imagePullPolicy | Specify a imagePullPolicy | string | `"Always"` |
+| test.image.pullSecrets | Optionally specify an array of imagePullSecrets (evaluated as templates) | list | `[]` |
 | test.image.registry | Test connection pod image registry | string | `"quay.io"` |
 | test.image.repository | Test connection pod image repository. Note that the image needs to have both the `sh` and `curl` binaries in it. | string | `"curl/curl"` |
 | test.image.tag | Test connection pod image tag. Note that the image needs to have both the `sh` and `curl` binaries in it. | string | `"latest"` |

--- a/charts/llm-d/templates/extra-deploy.yaml
+++ b/charts/llm-d/templates/extra-deploy.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/llm-d/values.schema.json
+++ b/charts/llm-d/values.schema.json
@@ -1,0 +1,1533 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "clusterDomain": {
+      "default": "cluster.local",
+      "description": "Default Kubernetes cluster domain",
+      "required": [],
+      "title": "clusterDomain"
+    },
+    "common": {
+      "additionalProperties": true,
+      "description": "Parameters for bitnami.common dependency",
+      "required": [],
+      "title": "common"
+    },
+    "commonAnnotations": {
+      "additionalProperties": true,
+      "description": "Annotations to add to all deployed objects",
+      "required": [],
+      "title": "commonAnnotations"
+    },
+    "commonLabels": {
+      "additionalProperties": true,
+      "description": "Labels to add to all deployed objects",
+      "required": [],
+      "title": "commonLabels"
+    },
+    "extraDeploy": {
+      "description": "Array of extra objects to deploy with the release",
+      "items": {
+        "required": [],
+        "type": [
+          "string",
+          "object"
+        ]
+      },
+      "required": [],
+      "title": "extraDeploy"
+    },
+    "fullnameOverride": {
+      "default": "",
+      "description": "String to fully override common.names.fullname",
+      "required": [],
+      "title": "fullnameOverride"
+    },
+    "gateway": {
+      "additionalProperties": false,
+      "default": "See below",
+      "description": "Gateway configuration",
+      "properties": {
+        "annotations": {
+          "additionalProperties": true,
+          "description": "Additional annotations provided to the Gateway resource",
+          "required": [],
+          "title": "annotations"
+        },
+        "enabled": {
+          "default": "true",
+          "description": "Deploy resources related to Gateway",
+          "required": [],
+          "title": "enabled"
+        },
+        "fullnameOverride": {
+          "default": "",
+          "description": "String to fully override gateway.fullname",
+          "required": [],
+          "title": "fullnameOverride"
+        },
+        "gatewayClassName": {
+          "default": "kgateway",
+          "description": "Gateway class that determines the backend used Currently supported values: \"kgateway\" or \"istio\"",
+          "required": [],
+          "title": "gatewayClassName"
+        },
+        "kGatewayParameters": {
+          "additionalProperties": false,
+          "description": "Special parameters applied to kGateway via GatewayParameters resource",
+          "properties": {
+            "proxyUID": {
+              "default": false,
+              "description": " type: [number, boolean] @schema",
+              "required": [],
+              "title": "proxyUID",
+              "type": [
+                "number",
+                "boolean"
+              ]
+            }
+          },
+          "required": [],
+          "title": "kGatewayParameters",
+          "type": "object"
+        },
+        "listeners": {
+          "description": " items:  type: object  properties:    name:      description: Name is the name of the Listener. This name MUST be unique within a Gateway      type: string    path:      description: Path to expose via Ingress      type: string    port:      description: Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules      type: integer      minimum: 1      maximum: 65535    protocol:      description: Protocol specifies the network protocol this listener expects to receive      type: string @schema Set of listeners exposed via the Gateway, also propagated to the Ingress if enabled",
+          "items": {
+            "properties": {
+              "name": {
+                "description": "Name is the name of the Listener. This name MUST be unique within a Gateway",
+                "required": [],
+                "type": "string"
+              },
+              "path": {
+                "description": "Path to expose via Ingress",
+                "required": [],
+                "type": "string"
+              },
+              "port": {
+                "description": "Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules",
+                "maximum": 65535,
+                "minimum": 1,
+                "required": [],
+                "type": "integer"
+              },
+              "protocol": {
+                "description": "Protocol specifies the network protocol this listener expects to receive",
+                "required": [],
+                "type": "string"
+              }
+            },
+            "required": [],
+            "type": "object"
+          },
+          "required": [],
+          "title": "listeners"
+        },
+        "nameOverride": {
+          "default": "",
+          "description": "String to partially override gateway.fullname",
+          "required": [],
+          "title": "nameOverride"
+        },
+        "serviceType": {
+          "default": "NodePort",
+          "description": "Gateway's service type. Ingress is only available if the service type is set to NodePort. Accepted values: [\"LoadBalancer\", \"NodePort\"]",
+          "required": [],
+          "title": "serviceType"
+        }
+      },
+      "required": [],
+      "title": "gateway"
+    },
+    "global": {
+      "additionalProperties": false,
+      "default": "See below",
+      "description": "Global parameters Global Docker image parameters Please, note that this will override the image parameters, including dependencies, configured to use the global value Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass",
+      "properties": {
+        "imagePullSecrets": {
+          "description": "Global Docker registry secret names as an array \u003c/br\u003e E.g. `imagePullSecrets: [myRegistryKeySecretName]`",
+          "items": {
+            "required": [],
+            "type": "string"
+          },
+          "required": [],
+          "title": "imagePullSecrets"
+        },
+        "imageRegistry": {
+          "default": "",
+          "description": "Global Docker image registry",
+          "required": [],
+          "title": "imageRegistry"
+        },
+        "security": {
+          "additionalProperties": false,
+          "properties": {
+            "allowInsecureImages": {
+              "default": true,
+              "required": [],
+              "title": "allowInsecureImages",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "security",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "global"
+    },
+    "ingress": {
+      "additionalProperties": false,
+      "default": "See below",
+      "description": "Ingress configuration",
+      "properties": {
+        "annotations": {
+          "additionalProperties": true,
+          "description": "Additional annotations for the Ingress resource",
+          "required": [],
+          "title": "annotations"
+        },
+        "enabled": {
+          "default": "true",
+          "description": "Deploy Ingress",
+          "required": [],
+          "title": "enabled"
+        },
+        "extraHosts": {
+          "description": "List of additional hostnames to be covered with this ingress record (e.g. a CNAME) \u003c!-- E.g. extraHosts:   - name: llm-d.env.example.com     path: / (Optional)     pathType: Prefix (Optional)     port: 7007 (Optional) --\u003e",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "extraHosts"
+        },
+        "extraTls": {
+          "description": "The TLS configuration for additional hostnames to be covered with this ingress record. \u003cbr /\u003e Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls \u003c!-- E.g. extraTls:   - hosts:     - llm-d.env.example.com     secretName: llm-d-env --\u003e",
+          "items": {
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.networking.v1.IngressTLS",
+            "required": []
+          },
+          "required": [],
+          "title": "extraTls"
+        },
+        "host": {
+          "default": "",
+          "description": "Hostname to be used to expose the NodePort service to the inferencing gateway",
+          "required": [],
+          "title": "host"
+        },
+        "ingressClassName": {
+          "default": "",
+          "description": "Name of the IngressClass cluster resource which defines which controller will implement the resource (e.g nginx)",
+          "required": [],
+          "title": "ingressClassName"
+        },
+        "path": {
+          "default": "/",
+          "description": "Path to be used to expose the full route to access the inferencing gateway",
+          "required": [],
+          "title": "path"
+        },
+        "tls": {
+          "additionalProperties": false,
+          "description": "Ingress TLS parameters",
+          "properties": {
+            "enabled": {
+              "default": "false",
+              "description": "Enable TLS configuration for the host defined at `ingress.host` parameter",
+              "required": [],
+              "title": "enabled"
+            },
+            "secretName": {
+              "default": "",
+              "description": "The name to which the TLS Secret will be called",
+              "required": [],
+              "title": "secretName"
+            }
+          },
+          "required": [],
+          "title": "tls"
+        }
+      },
+      "required": [],
+      "title": "ingress"
+    },
+    "kubeVersion": {
+      "default": "",
+      "description": "Override Kubernetes version",
+      "required": [],
+      "title": "kubeVersion"
+    },
+    "modelservice": {
+      "additionalProperties": false,
+      "default": "See below",
+      "description": "Model service controller configuration",
+      "properties": {
+        "annotations": {
+          "additionalProperties": true,
+          "description": "Annotations to add to all modelservice resources",
+          "required": [],
+          "title": "annotations"
+        },
+        "decode": {
+          "additionalProperties": false,
+          "default": "See below",
+          "description": "Decode options",
+          "properties": {
+            "tolerations": {
+              "default": "See below",
+              "description": "Tolerations configuration to deploy decode pods to tainted nodes",
+              "items": {
+                "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration",
+                "required": []
+              },
+              "required": [],
+              "title": "tolerations"
+            }
+          },
+          "required": [],
+          "title": "decode"
+        },
+        "enabled": {
+          "default": "true",
+          "description": "Toggle to deploy modelservice controller related resources",
+          "required": [],
+          "title": "enabled"
+        },
+        "epp": {
+          "additionalProperties": false,
+          "default": "See below",
+          "description": "Endpoint picker configuration",
+          "properties": {
+            "defaultEnvVars": {
+              "description": "Default environment variables for endpoint picker, use `extraEnvVars` to override default behavior by defining the same variable again. Ref: https://github.com/neuralmagic/gateway-api-inference-extension/tree/dev?tab=readme-ov-file#temporary-fork-configuration",
+              "items": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "ENABLE_KVCACHE_AWARE_SCORER",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "false",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "KVCACHE_AWARE_SCORER_WEIGHT",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "1.0",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "KVCACHE_INDEXER_REDIS_ADDR",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "{{ if .Values.redis.enabled }}{{ include \"redis.master.service.fullurl\" . }}{{ end }}",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "ENABLE_PREFIX_AWARE_SCORER",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "true",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "PREFIX_AWARE_SCORER_WEIGHT",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "2.0",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "ENABLE_LOAD_AWARE_SCORER",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "true",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "LOAD_AWARE_SCORER_WEIGHT",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "1.0",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "ENABLE_SESSION_AWARE_SCORER",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "false",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "SESSION_AWARE_SCORER_WEIGHT",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "1.0",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "PD_ENABLED",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "false",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "PD_PROMPT_LEN_THRESHOLD",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "10",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "PREFILL_ENABLE_KVCACHE_AWARE_SCORER",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "false",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "PREFILL_KVCACHE_AWARE_SCORER_WEIGHT",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "1.0",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "PREFILL_ENABLE_LOAD_AWARE_SCORER",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "false",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "PREFILL_LOAD_AWARE_SCORER_WEIGHT",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "1.0",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "PREFILL_ENABLE_PREFIX_AWARE_SCORER",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "false",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "PREFILL_PREFIX_AWARE_SCORER_WEIGHT",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "1.0",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "DECODE_ENABLE_KVCACHE_AWARE_SCORER",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "false",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "DECODE_KVCACHE_AWARE_SCORER_WEIGHT",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "1.0",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "DECODE_ENABLE_LOAD_AWARE_SCORER",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "false",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "DECODE_LOAD_AWARE_SCORER_WEIGHT",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "1.0",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "DECODE_ENABLE_PREFIX_AWARE_SCORER",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "false",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "name": {
+                        "default": "DECODE_PREFIX_AWARE_SCORER_WEIGHT",
+                        "required": [],
+                        "title": "name",
+                        "type": "string"
+                      },
+                      "value": {
+                        "default": "1.0",
+                        "required": [],
+                        "title": "value",
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  }
+                ],
+                "required": []
+              },
+              "required": [],
+              "title": "defaultEnvVars"
+            },
+            "extraEnvVars": {
+              "description": "Additional environment variables for endpoint picker",
+              "items": {
+                "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar",
+                "required": []
+              },
+              "required": [],
+              "title": "extraEnvVars"
+            },
+            "image": {
+              "additionalProperties": false,
+              "default": "See below",
+              "description": "Endpoint picker image used in ModelService CR presets",
+              "properties": {
+                "imagePullPolicy": {
+                  "default": "Always",
+                  "description": "Specify a imagePullPolicy",
+                  "required": [],
+                  "title": "imagePullPolicy"
+                },
+                "pullSecrets": {
+                  "description": "Optionally specify an array of imagePullSecrets (evaluated as templates)",
+                  "items": {
+                    "required": [],
+                    "type": "string"
+                  },
+                  "required": [],
+                  "title": "pullSecrets"
+                },
+                "registry": {
+                  "default": "quay.io",
+                  "description": "Endpoint picker image registry",
+                  "required": [],
+                  "title": "registry"
+                },
+                "repository": {
+                  "default": "llm-d/llm-d-inference-scheduler",
+                  "description": "Endpoint picker image repository",
+                  "required": [],
+                  "title": "repository"
+                },
+                "tag": {
+                  "default": "0.0.2",
+                  "description": "Endpoint picker image tag",
+                  "required": [],
+                  "title": "tag"
+                }
+              },
+              "required": [],
+              "title": "image"
+            },
+            "metrics": {
+              "additionalProperties": false,
+              "description": "Enable metrics gathering via podMonitor / ServiceMonitor",
+              "properties": {
+                "enabled": {
+                  "default": "true",
+                  "description": "Enable metrics scraping from endpoint picker service",
+                  "required": [],
+                  "title": "enabled"
+                },
+                "serviceMonitor": {
+                  "additionalProperties": false,
+                  "default": "See below",
+                  "description": "Prometheus ServiceMonitor configuration \u003cbr /\u003e Ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": true,
+                      "description": "Additional annotations provided to the ServiceMonitor",
+                      "required": [],
+                      "title": "annotations"
+                    },
+                    "interval": {
+                      "default": "10s",
+                      "description": "ServiceMonitor endpoint interval at which metrics should be scraped",
+                      "required": [],
+                      "title": "interval"
+                    },
+                    "labels": {
+                      "additionalProperties": true,
+                      "description": "Additional labels provided to the ServiceMonitor",
+                      "required": [],
+                      "title": "labels"
+                    },
+                    "namespaceSelector": {
+                      "additionalProperties": false,
+                      "description": "ServiceMonitor namespace selector",
+                      "properties": {
+                        "any": {
+                          "default": false,
+                          "required": [],
+                          "title": "any",
+                          "type": "boolean"
+                        },
+                        "matchNames": {
+                          "description": " items:   type: string @schema",
+                          "items": {
+                            "required": [],
+                            "type": "string"
+                          },
+                          "required": [],
+                          "title": "matchNames"
+                        }
+                      },
+                      "required": [],
+                      "title": "namespaceSelector"
+                    },
+                    "path": {
+                      "default": "/metrics",
+                      "description": "ServiceMonitor endpoint path",
+                      "required": [],
+                      "title": "path"
+                    },
+                    "port": {
+                      "default": "metrics",
+                      "description": "ServiceMonitor endpoint port",
+                      "required": [],
+                      "title": "port"
+                    },
+                    "selector": {
+                      "additionalProperties": false,
+                      "description": "ServiceMonitor selector matchLabels \u003c/br\u003e matchLabels must match labels on modelservice Services",
+                      "properties": {
+                        "matchLabels": {
+                          "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+                          "description": " $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector @schema",
+                          "required": []
+                        }
+                      },
+                      "required": [],
+                      "title": "selector"
+                    }
+                  },
+                  "required": [],
+                  "title": "serviceMonitor"
+                }
+              },
+              "required": [],
+              "title": "metrics"
+            }
+          },
+          "required": [],
+          "title": "epp"
+        },
+        "fullnameOverride": {
+          "default": "",
+          "description": "String to fully override modelservice.fullname",
+          "required": [],
+          "title": "fullnameOverride"
+        },
+        "image": {
+          "additionalProperties": false,
+          "default": "See below",
+          "description": "Modelservice controller image, please change only if appropriate adjustments to the CRD are being made",
+          "properties": {
+            "imagePullPolicy": {
+              "default": "Always",
+              "description": "Specify a imagePullPolicy",
+              "required": [],
+              "title": "imagePullPolicy"
+            },
+            "pullSecrets": {
+              "description": "Optionally specify an array of imagePullSecrets (evaluated as templates)",
+              "items": {
+                "required": [],
+                "type": "string"
+              },
+              "required": [],
+              "title": "pullSecrets"
+            },
+            "registry": {
+              "default": "quay.io",
+              "description": "Model Service controller image registry",
+              "required": [],
+              "title": "registry"
+            },
+            "repository": {
+              "default": "llm-d/llm-d-model-service",
+              "description": "Model Service controller image repository",
+              "required": [],
+              "title": "repository"
+            },
+            "tag": {
+              "default": "0.0.9",
+              "description": "Model Service controller image tag",
+              "required": [],
+              "title": "tag"
+            }
+          },
+          "required": [],
+          "title": "image"
+        },
+        "metrics": {
+          "additionalProperties": false,
+          "description": "Enable metrics gathering via podMonitor / ServiceMonitor",
+          "properties": {
+            "enabled": {
+              "default": "true",
+              "description": "Enable metrics scraping from prefill and decode services, see `model",
+              "required": [],
+              "title": "enabled"
+            },
+            "serviceMonitor": {
+              "additionalProperties": false,
+              "default": "See below",
+              "description": "Prometheus ServiceMonitor configuration \u003cbr /\u003e Ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": true,
+                  "description": "Additional annotations provided to the ServiceMonitor",
+                  "required": [],
+                  "title": "annotations"
+                },
+                "interval": {
+                  "default": "15s",
+                  "description": "ServiceMonitor endpoint interval at which metrics should be scraped",
+                  "required": [],
+                  "title": "interval"
+                },
+                "labels": {
+                  "additionalProperties": true,
+                  "description": "Additional labels provided to the ServiceMonitor",
+                  "required": [],
+                  "title": "labels"
+                },
+                "namespaceSelector": {
+                  "additionalProperties": false,
+                  "description": "ServiceMonitor namespace selector",
+                  "properties": {
+                    "any": {
+                      "default": false,
+                      "required": [],
+                      "title": "any",
+                      "type": "boolean"
+                    },
+                    "matchNames": {
+                      "description": " items:   type: string @schema",
+                      "items": {
+                        "required": [],
+                        "type": "string"
+                      },
+                      "required": [],
+                      "title": "matchNames"
+                    }
+                  },
+                  "required": [],
+                  "title": "namespaceSelector"
+                },
+                "path": {
+                  "default": "/metrics",
+                  "description": "ServiceMonitor endpoint path",
+                  "required": [],
+                  "title": "path"
+                },
+                "port": {
+                  "default": "vllm",
+                  "description": "ServiceMonitor endpoint port",
+                  "required": [],
+                  "title": "port"
+                },
+                "selector": {
+                  "additionalProperties": false,
+                  "description": "ServiceMonitor selector matchLabels \u003c/br\u003e matchLabels must match labels on modelservice Services",
+                  "properties": {
+                    "matchLabels": {
+                      "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+                      "description": " $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector @schema",
+                      "required": []
+                    }
+                  },
+                  "required": [],
+                  "title": "selector"
+                }
+              },
+              "required": [],
+              "title": "serviceMonitor"
+            }
+          },
+          "required": [],
+          "title": "metrics"
+        },
+        "nameOverride": {
+          "default": "",
+          "description": "String to partially override modelservice.fullname",
+          "required": [],
+          "title": "nameOverride"
+        },
+        "podAnnotations": {
+          "additionalProperties": true,
+          "description": "Pod annotations for modelservice",
+          "required": [],
+          "title": "podAnnotations"
+        },
+        "podLabels": {
+          "additionalProperties": true,
+          "description": "Pod labels for modelservice",
+          "required": [],
+          "title": "podLabels"
+        },
+        "prefill": {
+          "additionalProperties": false,
+          "default": "See below",
+          "description": "Prefill options",
+          "properties": {
+            "tolerations": {
+              "default": "See below",
+              "description": "Tolerations configuration to deploy prefill pods to tainted nodes",
+              "items": {
+                "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration",
+                "required": []
+              },
+              "required": [],
+              "title": "tolerations"
+            }
+          },
+          "required": [],
+          "title": "prefill"
+        },
+        "rbac": {
+          "additionalProperties": false,
+          "properties": {
+            "create": {
+              "default": "true",
+              "description": "Enable the creation of RBAC resources",
+              "required": [],
+              "title": "create"
+            }
+          },
+          "required": [],
+          "title": "rbac",
+          "type": "object"
+        },
+        "replicas": {
+          "default": "1",
+          "description": "Number of controller replicas",
+          "required": [],
+          "title": "replicas"
+        },
+        "routingProxy": {
+          "additionalProperties": false,
+          "default": "See below",
+          "description": "Routing proxy container options",
+          "properties": {
+            "image": {
+              "additionalProperties": false,
+              "description": "Routing proxy image used in ModelService CR presets",
+              "properties": {
+                "imagePullPolicy": {
+                  "default": "IfNotPresent",
+                  "description": "Specify a imagePullPolicy",
+                  "required": [],
+                  "title": "imagePullPolicy"
+                },
+                "pullSecrets": {
+                  "description": "Optionally specify an array of imagePullSecrets (evaluated as templates)",
+                  "items": {
+                    "required": [],
+                    "type": "string"
+                  },
+                  "required": [],
+                  "title": "pullSecrets"
+                },
+                "registry": {
+                  "default": "quay.io",
+                  "description": "Routing proxy image registry",
+                  "required": [],
+                  "title": "registry"
+                },
+                "repository": {
+                  "default": "llm-d/llm-d-routing-sidecar",
+                  "description": "Routing proxy image repository",
+                  "required": [],
+                  "title": "repository"
+                },
+                "tag": {
+                  "default": "0.0.6",
+                  "description": "Routing proxy image tag",
+                  "required": [],
+                  "title": "tag"
+                }
+              },
+              "required": [],
+              "title": "image"
+            }
+          },
+          "required": [],
+          "title": "routingProxy"
+        },
+        "service": {
+          "additionalProperties": false,
+          "description": "Model service controller settings",
+          "properties": {
+            "enabled": {
+              "default": "true",
+              "description": "Toggle to deploy a Service resource for Model service controller",
+              "required": [],
+              "title": "enabled"
+            },
+            "port": {
+              "default": "8443",
+              "description": "Port number exposed from Model Service controller",
+              "required": [],
+              "title": "port"
+            },
+            "type": {
+              "default": "ClusterIP",
+              "description": "Service type",
+              "required": [],
+              "title": "type"
+            }
+          },
+          "required": [],
+          "title": "service",
+          "type": "object"
+        },
+        "serviceAccount": {
+          "additionalProperties": false,
+          "default": "See below",
+          "description": "Service Account Configuration",
+          "properties": {
+            "annotations": {
+              "additionalProperties": true,
+              "description": "Additional custom annotations for the ServiceAccount.",
+              "required": [],
+              "title": "annotations"
+            },
+            "create": {
+              "default": "true",
+              "description": "Enable the creation of a ServiceAccount for Modelservice pods",
+              "required": [],
+              "title": "create"
+            },
+            "fullnameOverride": {
+              "default": "",
+              "description": "String to fully override modelservice.serviceAccountName, defaults to modelservice.fullname",
+              "required": [],
+              "title": "fullnameOverride"
+            },
+            "labels": {
+              "additionalProperties": true,
+              "description": "Additional custom labels to the service ServiceAccount.",
+              "required": [],
+              "title": "labels"
+            },
+            "nameOverride": {
+              "default": "",
+              "description": "String to partially override modelservice.serviceAccountName, defaults to modelservice.fullname",
+              "required": [],
+              "title": "nameOverride"
+            }
+          },
+          "required": [],
+          "title": "serviceAccount"
+        },
+        "vllm": {
+          "additionalProperties": false,
+          "default": "See below",
+          "description": "vLLM container options",
+          "properties": {
+            "image": {
+              "additionalProperties": false,
+              "default": "See below",
+              "description": "vLLM image used in ModelService CR presets",
+              "properties": {
+                "imagePullPolicy": {
+                  "default": "IfNotPresent",
+                  "description": "Specify a imagePullPolicy",
+                  "required": [],
+                  "title": "imagePullPolicy"
+                },
+                "pullSecrets": {
+                  "description": "Optionally specify an array of imagePullSecrets (evaluated as templates)",
+                  "items": {
+                    "required": [],
+                    "type": "string"
+                  },
+                  "required": [],
+                  "title": "pullSecrets"
+                },
+                "registry": {
+                  "default": "quay.io",
+                  "description": "llm-d image registry",
+                  "required": [],
+                  "title": "registry"
+                },
+                "repository": {
+                  "default": "llm-d/llm-d",
+                  "description": "llm-d image repository",
+                  "required": [],
+                  "title": "repository"
+                },
+                "tag": {
+                  "default": "0.0.7",
+                  "description": "llm-d image tag",
+                  "required": [],
+                  "title": "tag"
+                }
+              },
+              "required": [],
+              "title": "image"
+            },
+            "metrics": {
+              "additionalProperties": false,
+              "description": "Enable metrics gathering via podMonitor / ServiceMonitor",
+              "properties": {
+                "enabled": {
+                  "default": "true",
+                  "description": "Enable metrics scraping from prefill \u0026 decode services",
+                  "required": [],
+                  "title": "enabled"
+                }
+              },
+              "required": [],
+              "title": "metrics"
+            }
+          },
+          "required": [],
+          "title": "vllm"
+        },
+        "vllmSim": {
+          "additionalProperties": false,
+          "default": "See below",
+          "description": "vLL sim container options",
+          "properties": {
+            "image": {
+              "additionalProperties": false,
+              "default": "See below",
+              "description": "vLLM sim image used in ModelService CR presets",
+              "properties": {
+                "imagePullPolicy": {
+                  "default": "IfNotPresent",
+                  "description": "Specify a imagePullPolicy",
+                  "required": [],
+                  "title": "imagePullPolicy"
+                },
+                "pullSecrets": {
+                  "description": "Optionally specify an array of imagePullSecrets (evaluated as templates)",
+                  "items": {
+                    "required": [],
+                    "type": "string"
+                  },
+                  "required": [],
+                  "title": "pullSecrets"
+                },
+                "registry": {
+                  "default": "quay.io",
+                  "description": "vllm-sim image registry",
+                  "required": [],
+                  "title": "registry"
+                },
+                "repository": {
+                  "default": "llm-d/vllm-sim",
+                  "description": "vllm-sim image repository",
+                  "required": [],
+                  "title": "repository"
+                },
+                "tag": {
+                  "default": "0.0.4",
+                  "description": "vllm-sim image tag",
+                  "required": [],
+                  "title": "tag"
+                }
+              },
+              "required": [],
+              "title": "image"
+            }
+          },
+          "required": [],
+          "title": "vllmSim"
+        }
+      },
+      "required": [],
+      "title": "modelservice"
+    },
+    "nameOverride": {
+      "default": "",
+      "description": "String to partially override common.names.fullname",
+      "required": [],
+      "title": "nameOverride"
+    },
+    "redis": {
+      "$ref": "https://raw.githubusercontent.com/bitnami/charts/refs/tags/redis/20.13.4/bitnami/redis/values.schema.json",
+      "default": "Use sane defaults for minimal Redis deployment",
+      "description": "Bitnami/Redis chart configuration",
+      "required": []
+    },
+    "sampleApplication": {
+      "additionalProperties": false,
+      "default": "See below",
+      "description": "Sample application deploying a p-d pair of specific model",
+      "properties": {
+        "downloadModelJob": {
+          "additionalProperties": false,
+          "properties": {
+            "hfModelID": {
+              "default": "meta-llama/Llama-3.2-3B-Instruct",
+              "description": "If `.Values.sampleApplication.model.modelArtifactURI` starts with `pvc://` what huggingface repo to load onto the pvc",
+              "required": [],
+              "title": "hfModelID"
+            }
+          },
+          "required": [],
+          "title": "downloadModelJob",
+          "type": "object"
+        },
+        "enabled": {
+          "default": "true",
+          "description": "Enable rendering of sample application resources",
+          "required": [],
+          "title": "enabled"
+        },
+        "inferencePoolPort": {
+          "default": "8000",
+          "description": "InferencePool port configuration",
+          "required": [],
+          "title": "inferencePoolPort"
+        },
+        "model": {
+          "additionalProperties": false,
+          "properties": {
+            "auth": {
+              "additionalProperties": false,
+              "properties": {
+                "hfToken": {
+                  "additionalProperties": false,
+                  "description": "HF token auth config via k8s secret.",
+                  "properties": {
+                    "create": {
+                      "default": "true",
+                      "description": "If the secret should be created or one already exists",
+                      "required": [],
+                      "title": "create"
+                    },
+                    "key": {
+                      "default": "HF_TOKEN",
+                      "description": "Value of the token. Do not set this but use `envsubst` in conjunction with the helm chart",
+                      "required": [],
+                      "title": "key"
+                    },
+                    "name": {
+                      "default": "llm-d-hf-token",
+                      "description": "Name of the secret to create to store your huggingface token",
+                      "required": [],
+                      "title": "name"
+                    }
+                  },
+                  "required": [],
+                  "title": "hfToken"
+                }
+              },
+              "required": [],
+              "title": "auth",
+              "type": "object"
+            },
+            "modelArtifactURI": {
+              "default": "pvc://model-pvc/models/meta-llama/Llama-3.2-3B-Instruct",
+              "description": "Fully qualified pvc URI: pvc://\u003cpvc-name\u003e/\u003cmodel-path\u003e modelArtifactURI: pvc://llama-3.2-3b-instruct-pvc/models/meta-llama/Llama-3.2-3B-Instruct",
+              "required": [],
+              "title": "modelArtifactURI"
+            },
+            "modelName": {
+              "default": "meta-llama/Llama-3.2-3B-Instruct",
+              "description": "Name of the model",
+              "required": [],
+              "title": "modelName"
+            },
+            "servedModelNames": {
+              "description": "Aliases to the Model named vllm will serve with",
+              "items": {
+                "required": []
+              },
+              "required": [],
+              "title": "servedModelNames"
+            }
+          },
+          "required": [],
+          "title": "model",
+          "type": "object"
+        },
+        "resources": {
+          "additionalProperties": false,
+          "description": "Resource requests/limits \u003cbr /\u003e Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container",
+          "items": {
+            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+            "required": []
+          },
+          "properties": {
+            "limits": {
+              "additionalProperties": false,
+              "properties": {
+                "nvidia.com/gpu": {
+                  "default": 1,
+                  "required": [],
+                  "title": "nvidia.com/gpu",
+                  "type": "integer"
+                }
+              },
+              "required": [],
+              "title": "limits",
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": false,
+              "properties": {
+                "nvidia.com/gpu": {
+                  "default": "1",
+                  "description": " memory: 16Gi",
+                  "required": [],
+                  "title": "nvidia.com/gpu"
+                }
+              },
+              "required": [],
+              "title": "requests",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "resources"
+        }
+      },
+      "required": [],
+      "title": "sampleApplication"
+    },
+    "test": {
+      "additionalProperties": false,
+      "description": "Helm tests",
+      "properties": {
+        "enabled": {
+          "default": "false",
+          "description": "Enable rendering of helm test resources",
+          "required": [],
+          "title": "enabled"
+        },
+        "image": {
+          "additionalProperties": false,
+          "description": "See below",
+          "properties": {
+            "imagePullPolicy": {
+              "default": "Always",
+              "description": "Specify a imagePullPolicy",
+              "required": [],
+              "title": "imagePullPolicy"
+            },
+            "pullSecrets": {
+              "description": "Optionally specify an array of imagePullSecrets (evaluated as templates)",
+              "items": {
+                "required": [],
+                "type": "string"
+              },
+              "required": [],
+              "title": "pullSecrets"
+            },
+            "registry": {
+              "default": "quay.io",
+              "description": "Test connection pod image registry",
+              "required": [],
+              "title": "registry"
+            },
+            "repository": {
+              "default": "curl/curl",
+              "description": "Test connection pod image repository. Note that the image needs to have both the `sh` and `curl` binaries in it.",
+              "required": [],
+              "title": "repository"
+            },
+            "tag": {
+              "default": "latest",
+              "description": "Test connection pod image tag. Note that the image needs to have both the `sh` and `curl` binaries in it.",
+              "required": [],
+              "title": "tag"
+            }
+          },
+          "required": [],
+          "title": "image"
+        }
+      },
+      "required": [],
+      "title": "test"
+    }
+  },
+  "required": [],
+  "type": "object"
+}

--- a/charts/llm-d/values.yaml
+++ b/charts/llm-d/values.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=values.schema.json
+
 # Default values for the llm-d chart.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -11,12 +13,24 @@ global:
   # -- Global Docker image registry
   imageRegistry: ""
 
+  # @schema
+  # items:
+  #   type: string
+  # @schema
   # -- Global Docker registry secret names as an array
   # </br> E.g. `imagePullSecrets: [myRegistryKeySecretName]`
   imagePullSecrets: []
 
   security:
     allowInsecureImages: true
+
+
+# @schema
+# additionalProperties: true
+# @schema
+# -- Parameters for bitnami.common dependency
+common: {}
+
 # -- Common parameters
 # -- Override Kubernetes version
 kubeVersion: ""
@@ -30,12 +44,22 @@ fullnameOverride: ""
 # -- Default Kubernetes cluster domain
 clusterDomain: cluster.local
 
+# @schema
+# additionalProperties: true
+# @schema
 # -- Labels to add to all deployed objects
 commonLabels: {}
 
+# @schema
+# additionalProperties: true
+# @schema
 # -- Annotations to add to all deployed objects
 commonAnnotations: {}
 
+# @schema
+# items:
+#   type: [string, object]
+# @schema
 # -- Array of extra objects to deploy with the release
 extraDeploy: []
 
@@ -45,7 +69,9 @@ test:
   # -- Enable rendering of helm test resources
   enabled: false
 
+  # @default -- See below
   image:
+
     # -- Test connection pod image registry
     registry: quay.io
 
@@ -54,6 +80,17 @@ test:
 
     # -- Test connection pod image tag. Note that the image needs to have both the `sh` and `curl` binaries in it.
     tag: latest
+
+    # -- Specify a imagePullPolicy
+    imagePullPolicy: "Always"
+
+    # @schema
+    # items:
+    #   type: string
+    # @schema
+    # -- Optionally specify an array of imagePullSecrets (evaluated as templates)
+    pullSecrets: []
+
 # -- Sample application deploying a p-d pair of specific model
 # @default -- See below
 sampleApplication:
@@ -89,6 +126,10 @@ sampleApplication:
       # -- If `.Values.sampleApplication.model.modelArtifactURI` starts with `pvc://` what huggingface repo to load onto the pvc
     hfModelID: "meta-llama/Llama-3.2-3B-Instruct"
 
+  # @schema
+  # items:
+  #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements
+  # @schema
   # -- Modify resource limits/requests available to the pods
   # -- Resource requests/limits
   # <br /> Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
@@ -120,14 +161,38 @@ gateway:
   # Currently supported values: "kgateway" or "istio"
   gatewayClassName: kgateway
 
+  # @schema
+  # additionalProperties: true
+  # @schema
   # -- Additional annotations provided to the Gateway resource
   annotations: {}
 
   # Special parameters applied to kGateway via GatewayParameters resource
   kGatewayParameters:
-
+    # @schema
+    # type: [number, boolean]
+    # @schema
     proxyUID: false
 
+  # @schema
+  # items:
+  #  type: object
+  #  properties:
+  #    name:
+  #      description: Name is the name of the Listener. This name MUST be unique within a Gateway
+  #      type: string
+  #    path:
+  #      description: Path to expose via Ingress
+  #      type: string
+  #    port:
+  #      description: Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules
+  #      type: integer
+  #      minimum: 1
+  #      maximum: 65535
+  #    protocol:
+  #      description: Protocol specifies the network protocol this listener expects to receive
+  #      type: string
+  # @schema
   # Set of listeners exposed via the Gateway, also propagated to the Ingress if enabled
   listeners:
     - name: default
@@ -148,6 +213,9 @@ ingress:
   # -- Name of the IngressClass cluster resource which defines which controller will implement the resource (e.g nginx)
   ingressClassName: ""
 
+  # @schema
+  # additionalProperties: true
+  # @schema
   # -- Additional annotations for the Ingress resource
   annotations: {}
 
@@ -175,6 +243,10 @@ ingress:
     # -- The name to which the TLS Secret will be called
     secretName: ""
 
+  # @schema
+  # items:
+  #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.networking.v1.IngressTLS
+  # @schema
   # -- The TLS configuration for additional hostnames to be covered with this ingress record.
   # <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
   # <!-- E.g.
@@ -202,9 +274,15 @@ modelservice:
     # @default -- See below
     serviceMonitor:
 
+      # @schema
+      # additionalProperties: true
+      # @schema
       # -- Additional annotations provided to the ServiceMonitor
       annotations: {}
 
+      # @schema
+      # additionalProperties: true
+      # @schema
       # -- Additional labels provided to the ServiceMonitor
       labels: {}
 
@@ -220,11 +298,20 @@ modelservice:
       # -- ServiceMonitor namespace selector
       namespaceSelector:
         any: false
+
+        # @schema
+        # items:
+        #   type: string
+        # @schema
         matchNames: []
 
       # -- ServiceMonitor selector matchLabels
       # </br> matchLabels must match labels on modelservice Services
       selector:
+
+        # @schema
+        # $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+        # @schema
         matchLabels: {}
 
 
@@ -238,21 +325,53 @@ modelservice:
   replicas: 1
 
   # -- Modelservice controller image, please change only if appropriate adjustments to the CRD are being made
+  # @default -- See below
   image:
+
+    # -- Model Service controller image registry
     registry: quay.io
+
+    # -- Model Service controller image repository
     repository: llm-d/llm-d-model-service
+
+    # -- Model Service controller image tag
     tag: "0.0.9"
+
+    # -- Specify a imagePullPolicy
     imagePullPolicy: "Always"
+
+    # @schema
+    # items:
+    #   type: string
+    # @schema
+    # -- Optionally specify an array of imagePullSecrets (evaluated as templates)
+    pullSecrets: []
 
   # -- Endpoint picker configuration
   # @default -- See below
   epp:
     # -- Endpoint picker image used in ModelService CR presets
+    # @default -- See below
     image:
+
+      # -- Endpoint picker image registry
       registry: quay.io
+
+      # -- Endpoint picker image repository
       repository: llm-d/llm-d-inference-scheduler
+
+      # -- Endpoint picker image tag
       tag: 0.0.2
+
+    # -- Specify a imagePullPolicy
       imagePullPolicy: "Always"
+
+      # @schema
+      # items:
+      #   type: string
+      # @schema
+      # -- Optionally specify an array of imagePullSecrets (evaluated as templates)
+      pullSecrets: []
 
     # -- Enable metrics gathering via podMonitor / ServiceMonitor
     metrics:
@@ -265,9 +384,15 @@ modelservice:
       # @default -- See below
       serviceMonitor:
 
+        # @schema
+        # additionalProperties: true
+        # @schema
         # -- Additional annotations provided to the ServiceMonitor
         annotations: {}
 
+        # @schema
+        # additionalProperties: true
+        # @schema
         # -- Additional labels provided to the ServiceMonitor
         labels: {}
 
@@ -283,11 +408,20 @@ modelservice:
         # -- ServiceMonitor namespace selector
         namespaceSelector:
           any: false
+
+          # @schema
+          # items:
+          #   type: string
+          # @schema
           matchNames: []
 
         # -- ServiceMonitor selector matchLabels
         # </br> matchLabels must match labels on modelservice Services
         selector:
+
+          # @schema
+          # $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector
+          # @schema
           matchLabels: {}
 
     # -- Default environment variables for endpoint picker, use `extraEnvVars` to override default behavior by defining the same variable again.
@@ -339,6 +473,11 @@ modelservice:
         value: "false"
       - name: DECODE_PREFIX_AWARE_SCORER_WEIGHT
         value: "1.0"
+
+    # @schema
+    # items:
+    #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.EnvVar
+    # @schema
     # -- Additional environment variables for endpoint picker
     extraEnvVars: []
 
@@ -346,6 +485,10 @@ modelservice:
   # @default -- See below
   prefill:
 
+    # @schema
+    # items:
+    #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration
+    # @schema
     # -- Tolerations configuration to deploy prefill pods to tainted nodes
     # @default -- See below
     tolerations:
@@ -359,6 +502,10 @@ modelservice:
   # @default -- See below
   decode:
 
+    # @schema
+    # items:
+    #   $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration
+    # @schema
     # -- Tolerations configuration to deploy decode pods to tainted nodes
     # @default -- See below
     tolerations:
@@ -373,11 +520,27 @@ modelservice:
   vllm:
 
     # -- vLLM image used in ModelService CR presets
+    # @default -- See below
     image:
+
+      # -- llm-d image registry
       registry: quay.io
+
+      # -- llm-d image repository
       repository: "llm-d/llm-d"
+
+      # -- llm-d image tag
       tag: 0.0.7
+
+      # -- Specify a imagePullPolicy
       imagePullPolicy: "IfNotPresent"
+
+      # @schema
+      # items:
+      #   type: string
+      # @schema
+      # -- Optionally specify an array of imagePullSecrets (evaluated as templates)
+      pullSecrets: []
 
     # -- Enable metrics gathering via podMonitor / ServiceMonitor
     metrics:
@@ -388,30 +551,71 @@ modelservice:
   # -- Routing proxy container options
   # @default -- See below
   routingProxy:
+
     # -- Routing proxy image used in ModelService CR presets
     image:
+
+      # -- Routing proxy image registry
       registry: quay.io
+
+      # -- Routing proxy image repository
       repository: llm-d/llm-d-routing-sidecar
+
+      # -- Routing proxy image tag
       tag: "0.0.6"
-      imagePullPolicy: "Always"
+
+      # -- Specify a imagePullPolicy
+      imagePullPolicy: "IfNotPresent"
+
+      # @schema
+      # items:
+      #   type: string
+      # @schema
+      # -- Optionally specify an array of imagePullSecrets (evaluated as templates)
+      pullSecrets: []
 
   # -- vLL sim container options
   # @default -- See below
   vllmSim:
 
     # -- vLLM sim image used in ModelService CR presets
+    # @default -- See below
     image:
+
+      # -- vllm-sim image registry
       registry: quay.io
+
+      # -- vllm-sim image repository
       repository: llm-d/vllm-sim
+
+      # -- vllm-sim image tag
       tag: "0.0.4"
+
+      # -- Specify a imagePullPolicy
       imagePullPolicy: "IfNotPresent"
 
+      # @schema
+      # items:
+      #   type: string
+      # @schema
+      # -- Optionally specify an array of imagePullSecrets (evaluated as templates)
+      pullSecrets: []
+
+  # @schema
+  # additionalProperties: true
+  # @schema
   # -- Annotations to add to all modelservice resources
   annotations: {}
 
+  # @schema
+  # additionalProperties: true
+  # @schema
   # -- Pod annotations for modelservice
   podAnnotations: {}
 
+  # @schema
+  # additionalProperties: true
+  # @schema
   # -- Pod labels for modelservice
   podLabels: {}
 
@@ -440,9 +644,15 @@ modelservice:
     # --  String to partially override modelservice.serviceAccountName, defaults to modelservice.fullname
     nameOverride: ""
 
+    # @schema
+    # additionalProperties: true
+    # @schema
     # -- Additional custom labels to the service ServiceAccount.
     labels: {}
 
+    # @schema
+    # additionalProperties: true
+    # @schema
     # -- Additional custom annotations for the ServiceAccount.
     annotations: {}
 
@@ -450,6 +660,9 @@ modelservice:
     # -- Enable the creation of RBAC resources
     create: true
 
+# @schema
+# $ref: https://raw.githubusercontent.com/bitnami/charts/refs/tags/redis/20.13.4/bitnami/redis/values.schema.json
+# @schema
 # -- Bitnami/Redis chart configuration
 # @default -- Use sane defaults for minimal Redis deployment
 redis:


### PR DESCRIPTION
Adding a JSON schema to validate Helm values.

This PR documents remaining available values in `values.yaml`. Require testing various configurations we currently use, to confirm it does not violate the schema - in such case a schema needs to be adjusted.