### PR TITLE
include clusterRouterBase in the schema

### DIFF
--- a/charts/llm-d/Chart.yaml
+++ b/charts/llm-d/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: llm-d
 type: application
-version: 0.8.5
+version: 0.8.6
 appVersion: "0.0.1"
 icon: data:null
 description: A Helm chart for llm-d

--- a/charts/llm-d/README.md
+++ b/charts/llm-d/README.md
@@ -1,7 +1,7 @@
 
 # llm-d Helm Chart for OpenShift
 
-![Version: 0.8.5](https://img.shields.io/badge/Version-0.8.5-informational?style=flat-square)
+![Version: 0.8.6](https://img.shields.io/badge/Version-0.8.6-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for llm-d
@@ -156,6 +156,7 @@ Kubernetes: `>= 1.25.0-0`
 | global.imageRegistry | Global Docker image registry | string | `""` |
 | ingress | Ingress configuration | object | See below |
 | ingress.annotations | Additional annotations for the Ingress resource | object | `{}` |
+| ingress.clusterRouterBase | used as part of the host dirivation if not specified from OCP cluster domain (dont edit) | string | `""` |
 | ingress.enabled | Deploy Ingress | bool | `true` |
 | ingress.extraHosts | List of additional hostnames to be covered with this ingress record (e.g. a CNAME) <!-- E.g. extraHosts:   - name: llm-d.env.example.com     path: / (Optional)     pathType: Prefix (Optional)     port: 7007 (Optional) --> | list | `[]` |
 | ingress.extraTls | The TLS configuration for additional hostnames to be covered with this ingress record. <br /> Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls <!-- E.g. extraTls:   - hosts:     - llm-d.env.example.com     secretName: llm-d-env --> | list | `[]` |

--- a/charts/llm-d/values.schema.json
+++ b/charts/llm-d/values.schema.json
@@ -190,6 +190,12 @@
           "required": [],
           "title": "annotations"
         },
+        "clusterRouterBase": {
+          "default": "",
+          "description": "used as part of the host dirivation if not specified from OCP cluster domain (dont edit)",
+          "required": [],
+          "title": "clusterRouterBase"
+        },
         "enabled": {
           "default": "true",
           "description": "Deploy Ingress",

--- a/charts/llm-d/values.yaml
+++ b/charts/llm-d/values.yaml
@@ -274,6 +274,9 @@ ingress:
   #     secretName: llm-d-env -->
   extraTls: []
 
+  # -- used as part of the host dirivation if not specified from OCP cluster domain (dont edit)
+  clusterRouterBase: ""
+
 # -- Model service controller configuration
 # @default -- See below
 modelservice:


### PR DESCRIPTION
cc @tumido It won't let me `--set` values in quickstart without having it included in the schema. Having it in schema but not values fails precommit. Ergo were stuck with both ¯\_(ツ)_/¯
