### PR TITLE
Skip setting BASE_OCP_DOMAIN when not on OpenShift

### DIFF
--- a/quickstart/llmd-installer.sh
+++ b/quickstart/llmd-installer.sh
@@ -361,9 +361,8 @@ install() {
 
   if is_openshift; then
     BASE_OCP_DOMAIN=$(kubectl get ingresscontroller default -n openshift-ingress-operator -o jsonpath='{.status.domain}')
-  else 
+  else
     BASE_OCP_DOMAIN=""
-
   fi
 
   local metrics_enabled="true"


### PR DESCRIPTION
This is a fix? workaround? for the error:
```
error: the server doesn't have a resource type "ingresscontroller"
```