### PR TITLE
pvc log cleanup in uninstall

### DIFF
--- a/quickstart/llmd-installer.sh
+++ b/quickstart/llmd-installer.sh
@@ -464,8 +464,6 @@ uninstall() {
       log_info "🗑️ Deleting Model PV..."
       kubectl delete pv ${PV_NAME} --ignore-not-found
     fi
-  else
-    log_info "⏭️ skipping deletion of PV and PVCS..."
   fi
   log_success "💀 Uninstallation complete"
 }


### PR DESCRIPTION
- User doesn't care if the pv deletion was skipped if not PVC
- PVC gets deleted with the ns