### PR TITLE
chore(ci): change to using public images and no extra creds in GHA

### DIFF
--- a/.github/workflows/e2e-aws.yaml
+++ b/.github/workflows/e2e-aws.yaml
@@ -38,7 +38,6 @@ jobs:
       AMI_ID: ami-04f167a56786e4b09
       KEY_NAME: ${{ secrets.SSH_KEY_NAME }}
       REGION: ${{ secrets.AWS_REGION }}
-      GH_TOKEN: ${{secrets.GH_TOKEN}}
       HF_TOKEN: ${{secrets.HF_TOKEN}}
       TERMINATION_TIMEOUT: ${{ github.event.inputs.wait_for_termination }}
       PODS_READINESS_TIMEOUT: ${{ github.event.inputs.wait_for_pods }}
@@ -127,8 +126,7 @@ jobs:
             sudo apt-get update -y
             sudo apt-get install -y git
 
-            git clone https://$GH_TOKEN@github.com/llm-d/llm-d-deployer.git
-            git config --global url."https://$GH_TOKEN@github.com".insteadOf https://github.com
+            git clone https://github.com/llm-d/llm-d-deployer.git
             cd llm-d-deployer/quickstart
 
             ./install-deps.sh | tee ~/install-deps.log

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -56,11 +56,6 @@ jobs:
           sudo install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
           minikube start --driver=docker --nodes=2
 
-      - name: 🔐 Inject pull secrets
-        run: |
-          mkdir -p $HOME/.config/containers
-          echo "${{ secrets.AUTH_JSON }}" > $HOME/.config/containers/auth.json
-
       - name: 🔐 Inject HF token
         run: echo "HF_TOKEN=${{ secrets.HF_TOKEN }}" >> $GITHUB_ENV
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,7 @@
 name: Test Charts
 
 on:
-  # FIXME: Dangerous! Please revert to pull_request once images are public
-  pull_request_target: # zizmor: ignore[dangerous-triggers]
+  pull_request:
     branches:
       - main
   push:
@@ -22,14 +21,12 @@ jobs:
     # Aligning job name with the OpenShift CI config: https://github.com/openshift/release/blob/master/core-services/prow/02_config/redhat-developer/rhdh-chart/_prowconfig.yaml#L18
     name: Test Latest Release
     runs-on: ubuntu-latest
-    environment: ci
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
           persist-credentials: true
-          ref: ${{ github.event.pull_request.head.sha }}  # FiXME: Remove once reverted to pull_request from pull_request_target
 
       - name: Set up Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # renovate: tag=v3.5
@@ -59,22 +56,6 @@ jobs:
           helm repo add ingress-nginx "https://kubernetes.github.io/ingress-nginx"
           helm repo add bitnami "https://charts.bitnami.com/bitnami"
           helm repo update
-
-      # FIXME: Remove once images are public and this workflow is set to run to pull_request event instead of pull_request_target
-      - name: Login to Quay.io
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
-      # FIXME: Remove once images are public and this workflow is set to run to pull_request event instead of pull_request_target
-      - name: Login to ghcr.io
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_PASSWORD }}
 
       - name: Create KIND Cluster
         if: steps.list-changed.outputs.changed == 'true'
@@ -125,11 +106,7 @@ jobs:
       - name: Install prerequisites
         if: steps.list-changed.outputs.changed == 'true'
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GHCR_PASSWORD }}
-        run: |
-          git config --global url."https://$GITHUB_TOKEN@github.com".insteadOf https://github.com
-          ./chart-dependencies/ci-deps.sh
+        run: ./chart-dependencies/ci-deps.sh
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,16 +70,17 @@ pre-commit run -a
 For every Pull Request submitted, ensure the following steps have been done:
 
 1. [Sign your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
-2. Run `helm template` on the changes you're making to ensure they are correctly rendered into Kubernetes manifests.
-3. Lint tests has been run for the Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
-4. Ensure variables are documented in `values.yaml`. See section [Documenting Variables](#documenting-variables) below.
-5. Update the version number in the [`charts/llm-d/Chart.yaml`](charts/llm-d/Chart.yaml) file using
+2. [Sign-off your commits](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt-code--signoffcode)
+3. Run `helm template` on the changes you're making to ensure they are correctly rendered into Kubernetes manifests.
+4. Lint tests has been run for the Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
+5. Ensure variables are documented in `values.yaml`. See section [Documenting Variables](#documenting-variables) below.
+6. Update the version number in the [`charts/llm-d/Chart.yaml`](charts/llm-d/Chart.yaml) file using
    [semantic versioning](https://semver.org/). Follow the `X.Y.Z` format so the nature of the changes is reflected in the
    chart.
    - `X` (major) is incremented for breaking changes,
    - `Y` (minor) is incremented when new features are added without breaking existing functionality,
    - `Z` (patch) is incremented for bug fixes, minor improvements, or non-breaking changes.
-6. Make sure that [pre-commit](https://pre-commit.com/) hook has been run to generate/update the `README.md` documentation. To preview the content, use `helm-docs --dry-run`.
+7. Make sure that [pre-commit](https://pre-commit.com/) hook has been run to generate/update the `README.md` documentation. To preview the content, use `helm-docs --dry-run`.
 
 ### FAQ and Troubleshooting
 

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
The switch to public got my fork detached from the upstream repo. Had to fork again and reopen this PR as a new one.


Replaces: #232
Resolves: #5