### PR TITLE
chore: update install script to work with bash 3.2 / macOS

### DIFF
--- a/quickstart/llmd-installer.sh
+++ b/quickstart/llmd-installer.sh
@@ -453,7 +453,7 @@ fi
     ${DEBUG} \
     --namespace "${NAMESPACE}" \
     "${VALUES_ARGS[@]}" \
-    "${OCP_DISABLE_INGRESS_ARGS[@]}" \
+    ${OCP_DISABLE_INGRESS_ARGS+"${OCP_DISABLE_INGRESS_ARGS[@]}"} \
     --set gateway.kGatewayParameters.proxyUID="${PROXY_UID}" \
     --set ingress.clusterRouterBase="${BASE_OCP_DOMAIN}" \
     "${METRICS_ARGS[@]}"


### PR DESCRIPTION
chore: update install script to work with bash 3.2 / macOS

## Description

When using:

```
OCP_DISABLE_INGRESS_ARGS=()
```

It is incompatible with bash 3.2, resulting in a:

```
OCP_DISABLE_INGRESS_ARGS[@]: unbound variable
```

error.

Instead, we can use:

```
${OCP_DISABLE_INGRESS_ARGS+"${OCP_DISABLE_INGRESS_ARGS[@]}"}
```

Which detects to see if OCP_DISABLE_INGRESS_ARGS is set (even if it's
empty) then expand it. And if not, expand nothing at all. And removing
the error we are getting when installing on mac.

Fixes https://github.com/llm-d/llm-d-deployer/issues/267

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Run the installer on macOS and it'll work now :)

### Test Configuration

- Kubernetes version

## Checklist

- [X] My changes follows the style guidelines of this project
- [X] I have performed a self-review of my own changes
- [X] I confirm that my change can be rendered via `helm template`
- [X] I confirm that my change passes `helm lint`
- [X] I confirm that `pre-commit run` was run and all checks passed
- [X] I have updated the documentation accordingly
- [X] I have updated the chart version in `Chart.yaml` file and this change follow [semantic versioning](https://semver.org/) as described in the `CONTRIBUTING.md`

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
