### PR TITLE
chore: update script to include logging functions / output on macOS

### DIFF
--- a/chart-dependencies/ci-deps.sh
+++ b/chart-dependencies/ci-deps.sh
@@ -13,6 +13,13 @@ if [ -z "$(command -v kubectl)" ] || [ -z "$(command -v helm)" ]; then
     exit 1
 fi
 
+# Logging functions and ASCII colour helpers.
+COLOR_RESET=$'\e[0m'
+COLOR_GREEN=$'\e[32m'
+log_success() {
+  echo "${COLOR_GREEN}✅ $*${COLOR_RESET}"
+}
+
 CWD=$( dirname -- "$( readlink -f -- "$0"; )"; )
 
 ## Populate manifests
@@ -25,16 +32,15 @@ else
 fi
 
 ### Base CRDs
-echo -e "\e[32m📜 Base CRDs: ${LOG_ACTION_NAME}...\e[0m"
+log_success "📜 Base CRDs: ${LOG_ACTION_NAME}..."
 kubectl $MODE -k https://github.com/llm-d/llm-d-inference-scheduler/deploy/components/crds-gateway-api || true
 
 ### GAIE CRDs
-echo -e "\e[32m🚪 GAIE CRDs: ${LOG_ACTION_NAME}...\e[0m"
+log_success "🚪 GAIE CRDs: ${LOG_ACTION_NAME}..."
 kubectl $MODE -k https://github.com/llm-d/llm-d-inference-scheduler/deploy/components/crds-gie || true
 
 ### Install Gateway provider
 backend=$(helm show values $CWD/../charts/llm-d --jsonpath '{.gateway.gatewayClassName}')
-
-echo -e "\e[32m🎒 Gateway provider \e[0m '\e[34m$backend\e[0m'\e[32m: ${LOG_ACTION_NAME}...\e[0m"
+log_success "🎒 Gateway provider '${COLOR_BLUE}${backend}${COLOR_RESET}${COLOR_GREEN}': ${LOG_ACTION_NAME}...${COLOR_RESET}"
 
 $CWD/$backend/install.sh $MODE


### PR DESCRIPTION
chore: update script to include logging functions / output on macOS

## Description

macOS uses an older version of bash that makes the output odd, example:

```console
\e[32m🎒 Gateway provider \e[0m '\e[34mkgateway\e[0m'\e[32m: Deleting...\e[0m
```

This PR refactors the logging a bit in the installer as well as
`ci-deps.sh` to include helper logging functions for more consistent
output.

For example, here is some of the output:

```console
bash-3.2$ ./llmd-installer.sh
ℹ️  📂 Setting up script environment...
ℹ️  kubectl can reach to a running Kubernetes cluster.
✅ HF_TOKEN validated
ℹ️  🏗️ Installing GAIE Kubernetes infrastructure…
ℹ️  📜 Base CRDs: Installing...
customresourcedefinition.apiextensions.k8s.io/gatewayclasses.gateway.networking.k8s.io configured
customresourcedefinition.apiextensions.k8s.io/gateways.gateway.networking.k8s.io configured
customresourcedefinition.apiextensions.k8s.io/grpcroutes.gateway.networking.k8s.io configured
customresourcedefinition.apiextensions.k8s.io/httproutes.gateway.networking.k8s.io configured
customresourcedefinition.apiextensions.k8s.io/referencegrants.gateway.networking.k8s.io configured
ℹ️  🚪 GAIE CRDs: Installing...
customresourcedefinition.apiextensions.k8s.io/inferencemodels.inference.networking.x-k8s.io unchanged
customresourcedefinition.apiextensions.k8s.io/inferencepools.inference.networking.x-k8s.io unchanged
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/cdrage/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /Users/cdrage/.kube/config
✅ 🎒 Gateway provider 'kgateway': Installing...
```

Fixes https://github.com/llm-d/llm-d-deployer/issues/270

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested running the script again and it goes through fine / nicer
coloured output.

### Test Configuration

- Kubernetes version

Bare metal / personal cluster.

## Checklist

- [X] My changes follows the style guidelines of this project
- [X] I have performed a self-review of my own changes
- [X] I confirm that my change can be rendered via `helm template`
- [X] I confirm that my change passes `helm lint`
- [X] I confirm that `pre-commit run` was run and all checks passed
- [X] I have updated the documentation accordingly
- [X] I have updated the chart version in `Chart.yaml` file and this change follow [semantic versioning](https://semver.org/) as described in the `CONTRIBUTING.md`

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
