### PR TITLE
Set prometheus maximumStartupDurationSeconds to 300

### DIFF
--- a/quickstart/llmd-installer.sh
+++ b/quickstart/llmd-installer.sh
@@ -638,6 +638,7 @@ prometheus:
     serviceMonitorSelectorNilUsesHelmValues: false
     serviceMonitorSelector: {}
     serviceMonitorNamespaceSelector: {}
+    maximumStartupDurationSeconds: 300
 EOF
 
   helm install prometheus prometheus-community/kube-prometheus-stack \


### PR DESCRIPTION
When I ran ./llmd-installer.sh --minikube, I got the following error:

Error: INSTALLATION FAILED: 1 error occurred:
Prometheus.monitoring.coreos.com "prometheus-kube-prometheus-prometheus" is invalid: spec.maximumStartupDurationSeconds: Invalid value: 0: spec.maximumStartupDurationSeconds in body should be greater than or equal to 60

Setting maximumStartupDurationSeconds to 300 allowed Prometheus to start up.