### PR TITLE
add MODE variable to Istio installation script

### DIFF
--- a/chart-dependencies/istio/install.sh
+++ b/chart-dependencies/istio/install.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+MODE=${1:-apply}
 TAG=1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
 HUB=gcr.io/istio-testing
 


### PR DESCRIPTION
Hello maintainers, I'm trying to help fix https://github.com/llm-d/llm-d-deployer/issues/283.
With the MODE variable defined in Istio installation script, I have found that llm-d could be successfully deployed with gateway being set to istio.