### PR TITLE
fix the installer when not using openshift, and OCP_DISABLE_INGRESS_ARGS is empty

### DIFF
--- a/quickstart/llmd-installer.sh
+++ b/quickstart/llmd-installer.sh
@@ -469,7 +469,7 @@ fi
     ${DEBUG} \
     --namespace "${NAMESPACE}" \
     "${VALUES_ARGS[@]}" \
-    "${OCP_DISABLE_INGRESS_ARGS[@]}" \
+    "${OCP_DISABLE_INGRESS_ARGS[@]+"${OCP_DISABLE_INGRESS_ARGS[@]}"}" \
     --set gateway.kGatewayParameters.proxyUID="${PROXY_UID}" \
     --set ingress.clusterRouterBase="${BASE_OCP_DOMAIN}" \
     "${METRICS_ARGS[@]}"


### PR DESCRIPTION

If this empty, it doesn't expand properly and results in an unbounded variable:

```bash
./llmd-installer.sh: line 468: OCP_DISABLE_INGRESS_ARGS[@]: unbound variable    
```