### PR TITLE
Adds Multi-Arch and Multi-OS Support to install-deps.sh Script

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -35,10 +35,9 @@ Following prerequisite are required for the installer to work.
 - [Kustomize – official install docs](https://kubectl.docs.kubernetes.io/installation/kustomize/)
 - [kubectl – install & setup](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
-You can use the installer script that installs all the required dependencies.  Currently only Linux is supported.
+You can use the installer script that installs all the required dependencies.
 
 ```bash
-# Currently Linux only
 ./install-deps.sh
 ```
 


### PR DESCRIPTION
- `quickstart/README.md`: Removes "Linux only" references.
- `quickstart/install-deps.sh`:  Updates dep installations based on discovered OS and CPU architecture.

**Note:** No changes to `quickstart/llmd-installer.sh` were required to install llm-d from MacOS.

Fixes #290