### PR TITLE
[quickstart] feat: adds a new CLI option (`-g`/`--context`)

### DIFF
--- a/quickstart/llmd-installer.sh
+++ b/quickstart/llmd-installer.sh
@@ -53,7 +53,7 @@ Options:
   -D, --download-model             Download the model to PVC from Hugging Face
   -t, --download-timeout           Timeout for model download job
   -k, --minikube                   Deploy on an existing minikube instance with hostPath storage
-  -g, --context                    Supply a specific Kubernete/OpenShift context
+  -g, --context                    Supply a specific Kubernetes context
   -h, --help                       Show this help and exit
 EOF
 }

--- a/quickstart/llmd-installer.sh
+++ b/quickstart/llmd-installer.sh
@@ -17,6 +17,7 @@ HF_KEY=""
 PROXY_UID=""
 VALUES_FILE="values.yaml"
 DEBUG=""
+KUBERNETES_CONTEXT=""
 SKIP_INFRA=false
 INFRA_ONLY=false
 DOWNLOAD_ONLY=false
@@ -52,6 +53,7 @@ Options:
   -D, --download-model             Download the model to PVC from Hugging Face
   -t, --download-timeout           Timeout for model download job
   -k, --minikube                   Deploy on an existing minikube instance with hostPath storage
+  -g, --context                    Supply a specific Kubernete/OpenShift context
   -h, --help                       Show this help and exit
 EOF
 }
@@ -109,7 +111,7 @@ check_cluster_reachability() {
 fetch_kgateway_proxy_uid() {
   log_info "Fetching OCP proxy UID..."
   local uid_range
-  uid_range=$(kubectl get namespace "${NAMESPACE}" -o jsonpath='{.metadata.annotations.openshift\.io/sa\.scc\.uid-range}' 2>/dev/null || true)
+  uid_range=$($KCMD get namespace "${NAMESPACE}" -o jsonpath='{.metadata.annotations.openshift\.io/sa\.scc\.uid-range}' 2>/dev/null || true)
   if [[ -n "$uid_range" ]]; then
     PROXY_UID=$(echo "$uid_range" | awk -F'/' '{print $1 + 1}')
     log_success "Derived PROXY_UID=${PROXY_UID}"
@@ -135,6 +137,7 @@ parse_args() {
       -D|--download-model)             DOWNLOAD_MODEL="$2"; shift 2 ;;
       -t|--download-timeout)           DOWNLOAD_TIMEOUT="$2"; shift 2 ;;
       -k|--minikube)                   USE_MINIKUBE=true; shift ;;
+      -g|--context)                    KUBERNETES_CONTEXT="$2"; shift 2 ;;
       -h|--help)                       print_help; exit 0 ;;
       *)                               die "Unknown option: $1" ;;
     esac
@@ -193,6 +196,19 @@ setup_env() {
   if [[ "$SCRIPT_DIR" != "$INSTALL_DIR" ]]; then
     die "Script must be run from ${INSTALL_DIR}"
   fi
+
+  if [[ ! -z $KUBERNETES_CONTEXT ]]; then
+    if [[ ! -f $KUBERNETES_CONTEXT ]]; then
+      log_error "Error, the context file \"$KUBERNETES_CONTEXT\", passed via command-line option, does not exist!"
+      exit 1
+    fi
+    KCMD="kubectl --kubeconfig $KUBERNETES_CONTEXT"
+    HCMD="helm --kubeconfig $KUBERNETES_CONTEXT"
+
+  else
+    KCMD="kubectl"
+    HCMD="helm"
+  fi
 }
 
 validate_hf_token() {
@@ -206,7 +222,7 @@ validate_hf_token() {
 setup_minikube_storage() {
   log_info "📦 Setting up Minikube hostPath RWX Shared Storage..."
   log_info "🔄 Creating PV and PVC for llama model (PVC name: ${PVC_NAME})…"
-  kubectl apply -f - <<EOF
+  $KCMD apply -f - <<EOF
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -296,13 +312,13 @@ create_pvc_and_download_model_if_needed() {
       else
         # verify storage class exists
         log_info "🔍 Checking storage class \"${STORAGE_CLASS}\"..."
-        if ! kubectl get storageclass "${STORAGE_CLASS}" &>/dev/null; then
+        if ! $KCMD get storageclass "${STORAGE_CLASS}" &>/dev/null; then
           log_error "Storage class \`${STORAGE_CLASS}\` not found. Please create it or pass --storage-class with a valid class."
           exit 1
         fi
         # apply the storage manifest
         eval "echo \"$(cat ${REPO_ROOT}/helpers/k8s/model-storage-rwx-pvc-template.yaml)\"" \
-          | kubectl apply -n "${NAMESPACE}" -f -
+          | $KCMD apply -n "${NAMESPACE}" -f -
         log_success "PVC \`${PVC_NAME}\` created with storageClassName ${STORAGE_CLASS} and size ${STORAGE_SIZE}"
       fi
 
@@ -314,9 +330,9 @@ create_pvc_and_download_model_if_needed() {
         (.spec.template.spec.containers[0].env[] | select(.name == \"HF_TOKEN\")).valueFrom.secretKeyRef.name = \"${HF_TOKEN_SECRET_NAME}\" |
         (.spec.template.spec.containers[0].env[] | select(.name == \"HF_TOKEN\")).valueFrom.secretKeyRef.key = \"${HF_TOKEN_SECRET_KEY}\" |
         (.spec.template.spec.volumes[] | select(.name == \"model-cache\")).persistentVolumeClaim.claimName = \"${PVC_NAME}\"
-        " "${DOWNLOAD_MODEL_JOB_TEMPLATE_FILE_PATH}" | kubectl apply -f -
+        " "${DOWNLOAD_MODEL_JOB_TEMPLATE_FILE_PATH}" | $KCMD apply -f -
       elif [[ "${YQ_TYPE}" == "py" ]]; then
-        kubectl apply -f ${DOWNLOAD_MODEL_JOB_TEMPLATE_FILE_PATH} --dry-run=client -o yaml |
+        $KCMD apply -f ${DOWNLOAD_MODEL_JOB_TEMPLATE_FILE_PATH} --dry-run=client -o yaml |
         yq -r | \
         jq \
         --arg modelPath "${MODEL_PATH}" \
@@ -330,24 +346,24 @@ create_pvc_and_download_model_if_needed() {
         (.spec.template.spec.containers[] | select(.name == "downloader").env[] | select(.name == "HF_TOKEN")).valueFrom.secretKeyRef.name = $hfTokenSecretName |
         (.spec.template.spec.containers[] | select(.name == "downloader").env[] | select(.name == "HF_TOKEN")).valueFrom.secretKeyRef.key = $hfTokenSecretKey |
         (.spec.template.spec.volumes[] | select(.name == "model-cache")).persistentVolumeClaim.claimName = $pvcName
-        ' | yq -y | kubectl apply -n ${NAMESPACE} -f -
+        ' | yq -y | $KCMD apply -n ${NAMESPACE} -f -
       else
         log_error "unrecognized yq distro -- error"
         exit 1
       fi
 
       log_info "⏳ Waiting 30 seconds pod to start running model download job ..."
-      kubectl wait --for=condition=Ready pod/$(kubectl get pod --selector=job-name=download-model -o json | jq -r '.items[0].metadata.name') --timeout=60s || {
+      $KCMD wait --for=condition=Ready pod/$($KCMD get pod --selector=job-name=download-model -o json | jq -r '.items[0].metadata.name') --timeout=60s || {
         log_error "🙀 No pod picked up model download job";
         log_info "Please check your storageclass configuration for the \`download-model\` - if the PVC fails to spin the job will never get a pod"
-        kubectl logs job/download-model -n "${NAMESPACE}";
+        $KCMD logs job/download-model -n "${NAMESPACE}";
       }
 
       log_info "⏳ Waiting up to ${DOWNLOAD_TIMEOUT}s for model download job to complete; this may take a while depending on connection speed and model size..."
-      kubectl wait --for=condition=complete --timeout=${DOWNLOAD_TIMEOUT}s job/download-model -n "${NAMESPACE}" || {
+      $KCMD wait --for=condition=complete --timeout=${DOWNLOAD_TIMEOUT}s job/download-model -n "${NAMESPACE}" || {
         log_error "🙀 Model download job failed or timed out";
-        JOB_POD=$(kubectl get pod --selector=job-name=download-model -o json | jq -r '.items[0].metadata.name')
-        kubectl logs pod/${JOB_POD} -n "${NAMESPACE}";
+        JOB_POD=$($KCMD get pod --selector=job-name=download-model -o json | jq -r '.items[0].metadata.name')
+        $KCMD logs pod/${JOB_POD} -n "${NAMESPACE}";
         exit 1;
       }
 
@@ -379,14 +395,14 @@ install() {
     return 0
   fi
 
-  if kubectl get namespace "${MONITORING_NAMESPACE}" &>/dev/null; then
+  if $KCMD get namespace "${MONITORING_NAMESPACE}" &>/dev/null; then
     log_info "🧹 Cleaning up existing monitoring namespace..."
-    kubectl delete namespace "${MONITORING_NAMESPACE}" --ignore-not-found
+    $KCMD delete namespace "${MONITORING_NAMESPACE}" --ignore-not-found
   fi
 
   log_info "📦 Creating namespace ${NAMESPACE}..."
-  kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
-  kubectl config set-context --current --namespace="${NAMESPACE}"
+  $KCMD create namespace "${NAMESPACE}" --dry-run=client -o yaml | $KCMD apply -f -
+  $KCMD config set-context --current --namespace="${NAMESPACE}"
   log_success "Namespace ready"
 
   cd "${CHART_DIR}"
@@ -395,17 +411,17 @@ install() {
   log_info "🔐 Creating/updating HF token secret..."
   HF_NAME=$(yq -r .sampleApplication.model.auth.hfToken.name "${VALUES_PATH}")
   HF_KEY=$(yq -r .sampleApplication.model.auth.hfToken.key  "${VALUES_PATH}")
-  kubectl delete secret "${HF_NAME}" -n "${NAMESPACE}" --ignore-not-found
-  kubectl create secret generic "${HF_NAME}" \
+  $KCMD delete secret "${HF_NAME}" -n "${NAMESPACE}" --ignore-not-found
+  $KCMD create secret generic "${HF_NAME}" \
     --from-literal="${HF_KEY}=${HF_TOKEN}" \
-    --dry-run=client -o yaml | kubectl apply -f -
+    --dry-run=client -o yaml | $KCMD apply -f -
   log_success "HF token secret created"
 
   # can be fetched non-invasily if using kgateway or not
   fetch_kgateway_proxy_uid
 
   log_info "📜 Applying modelservice CRD..."
-  kubectl apply -f crds/modelservice-crd.yaml
+  $KCMD apply -f crds/modelservice-crd.yaml
   log_success "ModelService CRD applied"
 
   create_pvc_and_download_model_if_needed
@@ -414,13 +430,13 @@ install() {
     return 0
   fi
 
-  helm repo add bitnami  https://charts.bitnami.com/bitnami
+  $HCMD repo add bitnami  https://charts.bitnami.com/bitnami
   log_info "🛠️ Building Helm chart dependencies..."
-  helm dependency build .
+  $HCMD dependency build .
   log_success "Dependencies built"
 
   if is_openshift; then
-    BASE_OCP_DOMAIN=$(kubectl get ingresscontroller default -n openshift-ingress-operator -o jsonpath='{.status.domain}')
+    BASE_OCP_DOMAIN=$($KCMD get ingresscontroller default -n openshift-ingress-operator -o jsonpath='{.status.domain}')
     OCP_DISABLE_INGRESS_ARGS=(
       --set ingress.enabled=false
     )
@@ -480,7 +496,7 @@ else
 fi
 
   log_info "🚚 Deploying llm-d chart with ${VALUES_PATH}..."
-  helm upgrade -i llm-d . \
+  $HCMD upgrade -i llm-d . \
     ${DEBUG} \
     --namespace "${NAMESPACE}" \
     "${VALUES_ARGS[@]}" \
@@ -499,17 +515,17 @@ fi
 post_install() {
   # download-model pod deletion if it exists and in a succeeded phase
   local pod
-  pod=$(kubectl get pods -n "${NAMESPACE}" \
+  pod=$($KCMD get pods -n "${NAMESPACE}" \
     -l job-name=download-model \
     -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
   if [[ -z "$pod" ]]; then
     return
   fi
   local phase
-  phase=$(kubectl get pod "$pod" -n "${NAMESPACE}" \
+  phase=$($KCMD get pod "$pod" -n "${NAMESPACE}" \
     -o jsonpath='{.status.phase}' 2>/dev/null || true)
   if [[ "$phase" == "Succeeded" ]]; then
-    kubectl delete pod "$pod" -n "${NAMESPACE}" --ignore-not-found || true
+    $KCMD delete pod "$pod" -n "${NAMESPACE}" --ignore-not-found || true
     log_success "🧹 download-model pod deleted"
   else
     log_info "→ Pod ${pod} phase is ${phase}; skipping delete."
@@ -521,48 +537,48 @@ uninstall() {
     log_info "🗑️ Tearing down GAIE Kubernetes infrastructure…"
     bash ../chart-dependencies/ci-deps.sh delete
   fi
-  MODEL_ARTIFACT_URI=$(kubectl get modelservice --ignore-not-found -n ${NAMESPACE} -o yaml | yq '.items[].spec.modelArtifacts.uri')
+  MODEL_ARTIFACT_URI=$($KCMD get modelservice --ignore-not-found -n ${NAMESPACE} -o yaml | yq '.items[].spec.modelArtifacts.uri')
   PROTOCOL="${MODEL_ARTIFACT_URI%%://*}"
   if [[ "${PROTOCOL}" == "pvc" ]]; then
-    INFERENCING_DEPLOYMENT=$(kubectl get deployments --ignore-not-found  -n ${NAMESPACE} -l llm-d.ai/inferenceServing=true | tail -n 1 | awk '{print $1}')
-    PVC_NAME=$( kubectl get deployments --ignore-not-found  $INFERENCING_DEPLOYMENT -n ${NAMESPACE} -o yaml | yq '.spec.template.spec.volumes[] | select(has("persistentVolumeClaim"))' | yq .claimName)
-    PV_NAME=$(kubectl get pvc ${PVC_NAME} --ignore-not-found  -n ${NAMESPACE} -o yaml | yq .spec.volumeName)
-    kubectl delete job download-model --ignore-not-found || true
+    INFERENCING_DEPLOYMENT=$($KCMD get deployments --ignore-not-found  -n ${NAMESPACE} -l llm-d.ai/inferenceServing=true | tail -n 1 | awk '{print $1}')
+    PVC_NAME=$( $KCMD get deployments --ignore-not-found  $INFERENCING_DEPLOYMENT -n ${NAMESPACE} -o yaml | yq '.spec.template.spec.volumes[] | select(has("persistentVolumeClaim"))' | yq .claimName)
+    PV_NAME=$($KCMD get pvc ${PVC_NAME} --ignore-not-found  -n ${NAMESPACE} -o yaml | yq .spec.volumeName)
+    $KCMD delete job download-model --ignore-not-found || true
   fi
   log_info "🗑️ Uninstalling llm-d chart..."
-  helm uninstall llm-d --ignore-not-found --namespace "${NAMESPACE}" || true
+  $HCMD uninstall llm-d --ignore-not-found --namespace "${NAMESPACE}" || true
 
   log_info "🗑️ Deleting namespace ${NAMESPACE}..."
-  kubectl delete namespace "${NAMESPACE}" --ignore-not-found || true
+  $KCMD delete namespace "${NAMESPACE}" --ignore-not-found || true
 
   log_info "🗑️ Deleting monitoring namespace..."
-  kubectl delete namespace "${MONITORING_NAMESPACE}" --ignore-not-found || true
+  $KCMD delete namespace "${MONITORING_NAMESPACE}" --ignore-not-found || true
 
   # Check if we installed the Prometheus stack and delete the ServiceMonitor CRD if we did
-  if helm list -n "${MONITORING_NAMESPACE}" | grep -q "prometheus" 2>/dev/null; then
+  if $HCMD list -n "${MONITORING_NAMESPACE}" | grep -q "prometheus" 2>/dev/null; then
     log_info "🗑️ Deleting ServiceMonitor CRD..."
-    kubectl delete crd servicemonitors.monitoring.coreos.com --ignore-not-found || true
+    $KCMD delete crd servicemonitors.monitoring.coreos.com --ignore-not-found || true
   fi
 
   if [[ "${USE_MINIKUBE}" == "true" ]]; then
     log_info "🗑️ Deleting Minikube hostPath PV (${MODEL_PV_NAME})..."
-    kubectl delete pv "${MODEL_PV_NAME}" --ignore-not-found || true
+    $KCMD delete pv "${MODEL_PV_NAME}" --ignore-not-found || true
   fi
 
   log_info "🗑️ Deleting ClusterRoleBinding llm-d"
-  kubectl delete clusterrolebinding -l app.kubernetes.io/instance=llm-d
+  $KCMD delete clusterrolebinding -l app.kubernetes.io/instance=llm-d
 
   log_success "💀 Uninstallation complete"
 }
 
 check_servicemonitor_crd() {
   log_info "🔍 Checking for ServiceMonitor CRD (monitoring.coreos.com)..."
-  if ! kubectl get crd servicemonitors.monitoring.coreos.com &>/dev/null; then
+  if ! $KCMD get crd servicemonitors.monitoring.coreos.com &>/dev/null; then
     log_info "⚠️ ServiceMonitor CRD (monitoring.coreos.com) not found"
     return 1
   fi
 
-  API_VERSION=$(kubectl get crd servicemonitors.monitoring.coreos.com -o jsonpath='{.spec.versions[?(@.served)].name}' 2>/dev/null || echo "")
+  API_VERSION=$($KCMD get crd servicemonitors.monitoring.coreos.com -o jsonpath='{.spec.versions[?(@.served)].name}' 2>/dev/null || echo "")
 
   if [[ -z "$API_VERSION" ]]; then
     log_info "⚠️ Could not determine ServiceMonitor CRD API version"
@@ -586,7 +602,7 @@ check_openshift_monitoring() {
   log_info "🔍 Checking OpenShift user workload monitoring configuration..."
 
   # Check if user workload monitoring is enabled
-  if kubectl get configmap cluster-monitoring-config -n openshift-monitoring -o yaml 2>/dev/null | grep -q "enableUserWorkload: true"; then
+  if $KCMD get configmap cluster-monitoring-config -n openshift-monitoring -o yaml 2>/dev/null | grep -q "enableUserWorkload: true"; then
     log_success "✅ OpenShift user workload monitoring is properly configured"
     return 0
   fi
@@ -632,7 +648,7 @@ EOF
 
 is_openshift() {
   # Check for OpenShift-specific resources
-  if kubectl get clusterversion &>/dev/null; then
+  if $KCMD get clusterversion &>/dev/null; then
     return 0
   fi
   return 1
@@ -641,20 +657,20 @@ is_openshift() {
 install_prometheus_grafana() {
   log_info "🌱 Provisioning Prometheus operator…"
 
-  if ! kubectl get namespace "${MONITORING_NAMESPACE}" &>/dev/null; then
+  if ! $KCMD get namespace "${MONITORING_NAMESPACE}" &>/dev/null; then
     log_info "📦 Creating monitoring namespace..."
-    kubectl create namespace "${MONITORING_NAMESPACE}"
+    $KCMD create namespace "${MONITORING_NAMESPACE}"
   else
     log_info "📦 Monitoring namespace already exists"
   fi
 
-  if ! helm repo list 2>/dev/null | grep -q "prometheus-community"; then
+  if ! $HCMD repo list 2>/dev/null | grep -q "prometheus-community"; then
     log_info "📚 Adding prometheus-community helm repo..."
-    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-    helm repo update
+    $HCMD repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    $HCMD repo update
   fi
 
-  if helm list -n "${MONITORING_NAMESPACE}" | grep -q "prometheus"; then
+  if $HCMD list -n "${MONITORING_NAMESPACE}" | grep -q "prometheus"; then
     log_info "⚠️ Prometheus stack already installed in ${MONITORING_NAMESPACE} namespace"
     return 0
   fi
@@ -680,7 +696,7 @@ prometheus:
     maximumStartupDurationSeconds: 300
 EOF
 
-  helm install prometheus prometheus-community/kube-prometheus-stack \
+  $HCMD install prometheus prometheus-community/kube-prometheus-stack \
     --namespace "${MONITORING_NAMESPACE}" \
     -f /tmp/prometheus-values.yaml \
     1>/dev/null
@@ -688,8 +704,8 @@ EOF
   rm -f /tmp/prometheus-values.yaml
 
   log_info "⏳ Waiting for Prometheus stack pods to be ready..."
-  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=prometheus -n "${MONITORING_NAMESPACE}" --timeout=300s || true
-  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=grafana -n "${MONITORING_NAMESPACE}" --timeout=300s || true
+  $KCMD wait --for=condition=ready pod -l app.kubernetes.io/name=prometheus -n "${MONITORING_NAMESPACE}" --timeout=300s || true
+  $KCMD wait --for=condition=ready pod -l app.kubernetes.io/name=grafana -n "${MONITORING_NAMESPACE}" --timeout=300s || true
 
   log_success "🚀 Prometheus and Grafana installed."
 }


### PR DESCRIPTION
This new feature partially solves bug #272 by allowing an user to pass an specifiy configuratio/cluster/context file via a new CLI option.

In addition to "protect" the user's main `./kube/config`, this feature is useful in CI/CD and Benchmarking scenarios, where multiple different clusters are targeted simultaneously.