### PR TITLE
fix: install-deps.sh - handle kubectl installation on macOS without root group (#303)

### DIFF
--- a/quickstart/install-deps.sh
+++ b/quickstart/install-deps.sh
@@ -64,7 +64,11 @@ if ! command -v kubectl &> /dev/null; then
   echo "Installing kubectl..."
   K8S_URL="https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)"
   curl -LO "${K8S_URL}/bin/${OS}/${ARCH}/kubectl"
-  sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+  if [[ "$OS" == "darwin" ]]; then
+    sudo install -m 0755 kubectl /usr/local/bin/kubectl
+  else
+    sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+  fi
   rm kubectl
 fi
 


### PR DESCRIPTION
see issue 303 for full details.

after fix - 

`(.venv) ➜  quickstart git:(main) ✗ ./install-deps.sh
Installing kubectl...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   138  100   138    0     0   1363      0 --:--:-- --:--:-- --:--:--  1366
100 56.6M  100 56.6M    0     0  44.4M      0  0:00:01  0:00:01 --:--:-- 53.1M
Installing Helm...
--2025-06-05 11:14:26--  https://get.helm.sh/helm-v3.17.3-darwin-arm64.tar.gz
Resolving get.helm.sh (get.helm.sh)... 13.107.246.69
Connecting to get.helm.sh (get.helm.sh)|13.107.246.69|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 16649368 (16M) [application/x-tar]
Saving to: ‘helm-v3.17.3-darwin-arm64.tar.gz’

helm-v3.17.3-darwin-arm64.tar.gz 100%[==========================================================>]  15.88M  22.1MB/s    in 0.7s

2025-06-05 11:14:26 (22.1 MB/s) - ‘helm-v3.17.3-darwin-arm64.tar.gz’ saved [16649368/16649368]

x darwin-arm64/
x darwin-arm64/LICENSE
x darwin-arm64/helm
x darwin-arm64/README.md
Installing Kustomize...
All tools installed successfully.`