### PR TITLE
Fix: --download-model CLI parameter now correctly overrides template …

### DIFF
--- a/quickstart/llmd-installer.sh
+++ b/quickstart/llmd-installer.sh
@@ -495,6 +495,17 @@ else
   )
 fi
 
+# Override model configuration if --download-model is specified
+MODEL_OVERRIDE_ARGS=()
+if [[ -n "${DOWNLOAD_MODEL}" ]]; then
+  log_info "Overriding model configuration with user-specified model: ${DOWNLOAD_MODEL}"
+  MODEL_OVERRIDE_ARGS=(
+    --set sampleApplication.model.modelName="${DOWNLOAD_MODEL}"
+    --set sampleApplication.model.modelArtifactURI="pvc://model-pvc/${DOWNLOAD_MODEL}"
+  )
+  log_success "Model will be overridden: ${DOWNLOAD_MODEL}"
+fi
+
   log_info "🚚 Deploying llm-d chart with ${VALUES_PATH}..."
   $HCMD upgrade -i llm-d . \
     ${DEBUG} \
@@ -503,7 +514,8 @@ fi
     "${OCP_DISABLE_INGRESS_ARGS[@]+"${OCP_DISABLE_INGRESS_ARGS[@]}"}" \
     --set gateway.kGatewayParameters.proxyUID="${PROXY_UID}" \
     --set ingress.clusterRouterBase="${BASE_OCP_DOMAIN}" \
-    "${METRICS_ARGS[@]}"
+    "${METRICS_ARGS[@]}" \
+    "${MODEL_OVERRIDE_ARGS[@]}"
   log_success "llm-d deployed"
 
   post_install


### PR DESCRIPTION
Add MODEL_OVERRIDE_ARGS to process --download-model parameter - 
Fixes issue #319 where CLI parameter was silently ignored


Tested with --download-model facebook/opt-125m : 


ubuntu@ip-172-31-29-105:~$ sudo kubectl get pods --namespace llm-d
NAME                                             READY   STATUS    RESTARTS   AGE
facebook-opt-125m-decode-6cdbd8cc99-bpdfn        0/2     Pending   0          8m21s
facebook-opt-125m-epp-6df49df77f-2wtvt           1/1     Running   0          8m21s
llm-d-inference-gateway-istio-5f968c59f5-tjb4n   1/1     Running   0          8m24s
llm-d-modelservice-567b57d87-59cm4               1/1     Running   0          8m24s