### PR TITLE
fix: populate gateway.gatewayClassName helm value when the gateway type is not istio

### DIFF
--- a/chart-dependencies/ci-deps.sh
+++ b/chart-dependencies/ci-deps.sh
@@ -40,6 +40,6 @@ log_success "🚪 GAIE CRDs: ${LOG_ACTION_NAME}..."
 kubectl $MODE -k https://github.com/llm-d/llm-d-inference-scheduler/deploy/components/crds-gie || true
 
 ### Install Gateway provider
-log_success "🎒 Gateway provider '${COLOR_BLUE}${backend}${COLOR_RESET}${COLOR_GREEN}': ${LOG_ACTION_NAME}...${COLOR_RESET}"
+log_success "🎒 Gateway provider '${COLOR_BLUE}${BACKEND}${COLOR_RESET}${COLOR_GREEN}': ${LOG_ACTION_NAME}...${COLOR_RESET}"
 
 $CWD/$BACKEND/install.sh $MODE

--- a/quickstart/llmd-installer.sh
+++ b/quickstart/llmd-installer.sh
@@ -225,6 +225,13 @@ validate_hf_token() {
   fi
 }
 
+validate_gateway_type() {
+  if [[ "${GATEWAY_TYPE}" != "istio" && "${GATEWAY_TYPE}" != "kgateway" ]]; then
+    die "Invalid gateway type: ${GATEWAY_TYPE}. Supported types are: istio, kgateway."
+  fi
+  log_success "Gateway type validated"
+}
+
 setup_minikube_storage() {
   log_info "📦 Setting up Minikube hostPath RWX Shared Storage..."
   log_info "🔄 Creating PV and PVC for llama model (PVC name: ${PVC_NAME})…"
@@ -518,10 +525,11 @@ fi
     --namespace "${NAMESPACE}" \
     "${VALUES_ARGS[@]}" \
     "${OCP_DISABLE_INGRESS_ARGS[@]+"${OCP_DISABLE_INGRESS_ARGS[@]}"}" \
+    --set gateway.gatewayClassName="${GATEWAY_TYPE}" \
     --set gateway.kGatewayParameters.proxyUID="${PROXY_UID}" \
     --set ingress.clusterRouterBase="${BASE_OCP_DOMAIN}" \
     "${METRICS_ARGS[@]}" \
-    "${MODEL_OVERRIDE_ARGS[@]}"
+    "${MODEL_OVERRIDE_ARGS[@]+"${MODEL_OVERRIDE_ARGS[@]}"}"
   log_success "$HELM_RELEASE_NAME deployed"
 
   post_install
@@ -738,6 +746,7 @@ main() {
   check_cluster_reachability
 
   validate_hf_token
+  validate_gateway_type
 
   if [[ "$ACTION" == "install" ]]; then
     install


### PR DESCRIPTION
- I was getting a `unbound variable` error for `MODEL_OVERRIDE_ARGS` when installing llm-d with `quickstart/llmd-installer.sh`. This fix will ensure the script passes even if the variable is an empty array.
- Added `gateway.gatewayClassName` in helm install command
