### PR TITLE
fix: correct --download-model to use HuggingFace URI instead of PVC 

### DIFF
--- a/quickstart/llmd-installer.sh
+++ b/quickstart/llmd-installer.sh
@@ -507,7 +507,7 @@ if [[ -n "${DOWNLOAD_MODEL}" ]]; then
   log_info "Overriding model configuration with user-specified model: ${DOWNLOAD_MODEL}"
   MODEL_OVERRIDE_ARGS=(
     --set sampleApplication.model.modelName="${DOWNLOAD_MODEL}"
-    --set sampleApplication.model.modelArtifactURI="pvc://model-pvc/${DOWNLOAD_MODEL}"
+    --set sampleApplication.model.modelArtifactURI="hf://${DOWNLOAD_MODEL}"
   )
   log_success "Model will be overridden: ${DOWNLOAD_MODEL}"
 fi


### PR DESCRIPTION
Additional fix needed for #320 to use HF and not PVC.

Current behavior: --download-model Qwen/Qwen3-0.6B → pvc://model-pvc/Qwen/Qwen3-0.6B → Broken hybrid mode
Fixed behavior: --download-model Qwen/Qwen3-0.6B → hf://Qwen/Qwen3-0.6B → Proper HuggingFace download

Tested full deployment ( now including looking into the pod ) 



INFO 06-18 01:46:26 [cli_args.py:297] non-default args: {'port': 8001, 'served_model_name': ['Qwen/Qwen3-0.6B']}

