### PR TITLE
Added Gateway API Inference Extension (GIE) installation for quickstart docs

### DIFF
--- a/quickstart/README-minikube.md
+++ b/quickstart/README-minikube.md
@@ -34,7 +34,7 @@ You can use the installer script that installs all the required dependencies. Th
 ### Required [Gateway API Inference Extension (GIE)]
 
 ```shell
-export GIE_VERSION=v0.8.0
+export GIE_VERSION=v0.3.0
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/$GIE_VERSION/manifests.yaml
 ```
 

--- a/quickstart/README-minikube.md
+++ b/quickstart/README-minikube.md
@@ -31,6 +31,13 @@ You can use the installer script that installs all the required dependencies. Th
 > ⚠️ You may need to visit Hugging Face [meta-llama/Llama-3.2-3B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct) and
 > accept the usage terms to pull this with your HF token if you have not already done so.
 
+### Required [Gateway API Inference Extension (GIE)]
+
+```shell
+export GIE_VERSION=v0.8.0
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/$GIE_VERSION/manifests.yaml
+```
+
 ### Target Platform
 
 #### MiniKube
@@ -300,3 +307,5 @@ To delete the Minikube cluster, simply run:
 ```bash
 minikube delete
 ```
+
+[Gateway API Inference Extension (GIE)]:https://github.com/kubernetes-sigs/gateway-api-inference-extension

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -49,6 +49,13 @@ You can use the installer script that installs all the required dependencies.
 > ⚠️ Your Hugging Face account must have access to the model you want to use.  You may need to visit Hugging Face [meta-llama/Llama-3.2-3B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct) and
 > accept the usage terms if you have not already done so.
 
+### Required [Gateway API Inference Extension (GIE)]
+
+```shell
+export GIE_VERSION=v0.8.0
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/$GIE_VERSION/manifests.yaml
+```
+
 ### Target Platforms
 
 Since the llm-d-deployer is based on helm charts, llm-d can be deployed on a variety of Kubernetes platforms. As more platforms are supported, the installer will be updated to support them.
@@ -347,3 +354,5 @@ make a change, simply uninstall and then run the installer again with any change
 ```bash
 ./llmd-installer.sh --uninstall
 ```
+
+[Gateway API Inference Extension (GIE)]:https://github.com/kubernetes-sigs/gateway-api-inference-extension

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -52,7 +52,7 @@ You can use the installer script that installs all the required dependencies.
 ### Required [Gateway API Inference Extension (GIE)]
 
 ```shell
-export GIE_VERSION=v0.8.0
+export GIE_VERSION=v0.3.0
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/$GIE_VERSION/manifests.yaml
 ```
 


### PR DESCRIPTION
## Summary

Currently, if [Gateway API Inference Extension (GIE)](https://github.com/kubernetes-sigs/gateway-api-inference-extension) not installed in a fresh new testing used cluster, the following error will throw when following the guide of [Quickstart](https://github.com/llm-d/llm-d-deployer/tree/main/quickstart), and for the `helm install`ed release, the created `llm-d-modelservice` will fail due to timeout on waiting CRD points to `InferencePool.inference.networking.x-k8s.io`:

```
{
  "level": "error",
  "ts": "2025-06-20T11:02:53.466245232Z",
  "logger": "controller-runtime.source.EventHandler",
  "caller": "source/kind.go:71",
  "msg": "if kind is a CRD, it should be installed before calling Start",
  "kind": "InferencePool.inference.networking.x-k8s.io",
  "error": "no matches for kind \"InferencePool\" in version \"inference.networking.x-k8s.io/v1alpha2\"",
  "stacktrace": "sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/source/kind.go:71\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.33.0/pkg/util/wait/loop.go:53\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\t/go/pkg/mod/k8s.io/apimachinery@v0.33.0/pkg/util/wait/loop.go:54\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\t/go/pkg/mod/k8s.io/apimachinery@v0.33.0/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind[...]).Start.func1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/source/kind.go:64"
}
```

While I do discovered that https://github.com/llm-d/llm-d-deployer/pull/321 is currently pending to be merged for adding the Inference Extension (GIE) as a sub chart, for others who currently trying out `llm-d`, it's obvious that missing pieces of GIE will result in errors.

This Pull Reuqest temporarily add a new section for asking to install GIE before installation.

## Related

Related to https://github.com/llm-d/llm-d-deployer/issues/312.
Workaround for https://github.com/llm-d/llm-d-deployer/pull/321