### PR TITLE
Charts: Bumps Kgateway to v2.0.3

### DIFF
--- a/chart-dependencies/kgateway/install.sh
+++ b/chart-dependencies/kgateway/install.sh
@@ -6,13 +6,13 @@ if [[ "$MODE" == "apply" ]]; then
   helm upgrade -i \
     --namespace kgateway-system \
     --create-namespace \
-    --version v2.0.0 \
+    --version v2.0.3 \
     kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds
 
   helm upgrade -i \
     --namespace kgateway-system \
     --create-namespace \
-    --version v2.0.0 \
+    --version v2.0.3 \
     --set inferenceExtension.enabled=true \
     --set securityContext.allowPrivilegeEscalation=false \
     --set securityContext.capabilities.drop={ALL} \
@@ -22,5 +22,5 @@ if [[ "$MODE" == "apply" ]]; then
 else
   helm uninstall kgateway --ignore-not-found  --namespace kgateway-system || true
   helm uninstall kgateway-crds --ignore-not-found --namespace kgateway-system || true
-  helm template kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds --version v2.0.0 | kubectl delete -f - --ignore-not-found
+  helm template kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds --version v2.0.3 | kubectl delete -f - --ignore-not-found
 fi


### PR DESCRIPTION
Bumps the Kgateway chart dep script to [v2.0.3](https://github.com/kgateway-dev/kgateway/releases/tag/v2.0.3).

I used [this env](https://gist.github.com/danehans/834509a5cd6094bd53c035a4e49d39dd) to test multi-route/multi-pool inference with kgtw v2.0.3:

```sh
$ k get deploy/kgateway -n kgateway-system -o yaml | grep image
        image: cr.kgateway.dev/kgateway-dev/kgateway:v2.0.3
        imagePullPolicy: IfNotPresent
$ k get gtw
NAME                      CLASS      ADDRESS       PROGRAMMED   AGE
llm-d-inference-gateway   kgateway   10.96.48.67   True         178m
$ k get httproute/meta-llama-llama-3-2-3b-instruct
NAME                               HOSTNAMES   AGE
meta-llama-llama-3-2-3b-instruct               178m
$ kubectl exec po/curl -- curl -i "10.96.48.67/v1/completions" -H 'x-model-name: facebook/llama3-8b-instruct' -H 'Content-Type: application/json' -d '{"model": "meta-llama/Llama-3.2-3B-Instruct","prompt": "Write as if you were a critic: San Francisco","max_tokens": 100,"temperature": 0}'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0HTTP/1.1 200 OK
x-envoy-upstream-service-time: 0
x-went-into-resp-headers: true
content-type: application/json
date: Mon, 30 Jun 2025 19:22:58 GMT
server: envoy
transfer-encoding: chunked

{"choices":[{"finish_reason":"stop","index":0,"text":"Today is a nice sunny day."}],"created":1751311378,"id":"chatcmpl-0b25ec03-a135-4d2e-91db-a70a518b23c0","model":"meta-l100   433    0   296  100   137  17449   8076 --:--:-- --:--:-- --:--:-- 27062kens":6,"prompt_tokens":9,"total_tokens":15}}
$ kubectl exec po/curl -- curl -i "10.96.48.67/v1/completions" -H 'x-model-name: facebook/llama3-8b-instruct-2' -H 'Content-Type: application/json' -d '{"model": "meta-llama/Llama-3.2-3B-Instruct","prompt": "Write as if you were a critic: San Francisco","max_tokens": 100,"temperature": 0}'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   448    0   311  100   137  17434   7680 --:--:-- --:--:-- --:--:-- 26352
HTTP/1.1 200 OK
x-envoy-upstream-service-time: 0
x-went-into-resp-headers: true
content-type: application/json
date: Mon, 30 Jun 2025 19:23:05 GMT
server: envoy
transfer-encoding: chunked

{"choices":[{"finish_reason":"stop","index":0,"text":"Today it is partially cloudy and raining."}],"created":1751311386,"id":"chatcmpl-6f90d7a5-b3b3-4cfa-a96f-37f62db57a1d","model":"meta-llama/Llama-3.2-3B-Instruct","object":"text_completion","usage":{"completion_tokens":7,"prompt_tokens":9,"total_tokens":16}}solo-
```

Fixes https://github.com/llm-d/llm-d-inference-scheduler/issues/158