### PR TITLE
fix: Enable HTTP proxy support by removing sudo from curl commands in `quickstart/install-deps.sh`

### DIFF
--- a/quickstart/install-deps.sh
+++ b/quickstart/install-deps.sh
@@ -49,9 +49,15 @@ done
 # Install yq (v4+)
 if ! command -v yq &> /dev/null; then
   echo "Installing yq..."
-  sudo curl -sLo /usr/local/bin/yq \
+  curl -sLo yq \
     "https://github.com/mikefarah/yq/releases/latest/download/yq_${OS}_${ARCH}"
-  sudo chmod +x /usr/local/bin/yq
+  chmod +x yq
+  sudo mv yq /usr/local/bin/yq
+fi
+
+if ! yq --version 2>&1 | grep -q 'mikefarah'; then
+  echo "Detected yq is not mikefarah’s yq. Please uninstall your current yq and re-run this script."
+  exit 1
 fi
 
 # Install kubectl


### PR DESCRIPTION
### Problem

When using sudo curl in the installation script, HTTP proxy environment variables (such as http_proxy, https_proxy, no_proxy) are not inherited by the curl process running under sudo. This causes network requests to fail in proxy environments.  

### Solution

Modified the yq installation process in quickstart/install-deps.sh:  
• Replaced `sudo curl -sLo /usr/local/bin/yq` with `curl -sLo yq` followed by `sudo mv yq /usr/local/bin/yq`
• Added a verification step to ensure yq is correctly installed (to address potential issues like an incorrect version being installed).